### PR TITLE
Security hardening, quality fixes & extensions (multi-agent audit)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,20 +29,20 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Dump Autoload
-      run: composer dump-autoload -o
-      
     - name: Cache Composer packages
       id: composer-cache
       uses: actions/cache@v3
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-php-
+          ${{ runner.os }}-php-${{ matrix.php-version }}-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-interaction
+
+    - name: Dump Autoload
+      run: composer dump-autoload -o
 
     - name: Copy phpunit.xml
       run: php -r "file_exists('phpunit.xml') || copy('phpunit.xml.dist', 'phpunit.xml');"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "guzzlehttp/guzzle": "^7.10",
         "dschuppelius/php-common-toolkit": "^1.0",
         "dschuppelius/php-error-toolkit": "^2.4",
-        "ramsey/uuid": "^4.9"
+        "ramsey/uuid": "^4.9",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7aa0f322ffd1704791088b80c6ed12fb",
+    "content-hash": "6dc8164dcd481ac2e6c44b2953bd7f12",
     "packages": [
         {
             "name": "brick/math",
@@ -67,16 +67,16 @@
         },
         {
             "name": "dschuppelius/php-common-toolkit",
-            "version": "v1.15.8",
+            "version": "v1.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DSchuppelius/php-common-toolkit.git",
-                "reference": "5f88b8188b1f6cba2e3c60c102dacd1f16a13f8f"
+                "reference": "cd6c2f0ce922bdeae0a6aa7e514f2e52842c2c1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DSchuppelius/php-common-toolkit/zipball/5f88b8188b1f6cba2e3c60c102dacd1f16a13f8f",
-                "reference": "5f88b8188b1f6cba2e3c60c102dacd1f16a13f8f",
+                "url": "https://api.github.com/repos/DSchuppelius/php-common-toolkit/zipball/cd6c2f0ce922bdeae0a6aa7e514f2e52842c2c1a",
+                "reference": "cd6c2f0ce922bdeae0a6aa7e514f2e52842c2c1a",
                 "shasum": ""
             },
             "require": {
@@ -85,6 +85,7 @@
                 "ext-dom": "*",
                 "ext-intl": "*",
                 "ext-zip": "*",
+                "maxmind-db/reader": "^1.11",
                 "php": ">=8.1 <8.6"
             },
             "require-dev": {
@@ -111,9 +112,9 @@
             "description": "Project description.",
             "support": {
                 "issues": "https://github.com/DSchuppelius/php-common-toolkit/issues",
-                "source": "https://github.com/DSchuppelius/php-common-toolkit/tree/v1.15.8"
+                "source": "https://github.com/DSchuppelius/php-common-toolkit/tree/v1.16.4"
             },
-            "time": "2026-07-13T17:47:42+00:00"
+            "time": "2026-07-19T19:35:14+00:00"
         },
         {
             "name": "dschuppelius/php-config-toolkit",
@@ -219,22 +220,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.14.1",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
-                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.12.5",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -247,7 +248,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.3",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -327,7 +328,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.14.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -343,7 +344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T01:32:54+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -431,16 +432,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.5",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -530,7 +531,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -546,7 +547,71 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T01:27:20+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
+        },
+        {
+            "name": "maxmind-db/reader",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maxmind/MaxMind-DB-Reader-php.git",
+                "reference": "2194f58d0f024ce923e685cdf92af3daf9951908"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maxmind/MaxMind-DB-Reader-php/zipball/2194f58d0f024ce923e685cdf92af3daf9951908",
+                "reference": "2194f58d0f024ce923e685cdf92af3daf9951908",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "conflict": {
+                "ext-maxminddb": "<1.11.1 || >=2.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": ">=8.0.0,<10.0.0",
+                "squizlabs/php_codesniffer": "4.*"
+            },
+            "suggest": {
+                "ext-bcmath": "bcmath or gmp is required for decoding larger integers with the pure PHP decoder",
+                "ext-gmp": "bcmath or gmp is required for decoding larger integers with the pure PHP decoder",
+                "ext-maxminddb": "A C-based database decoder that provides significantly faster lookups",
+                "maxmind-db/reader-ext": "C extension for significantly faster IP lookups (install via PIE: pie install maxmind-db/reader-ext)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MaxMind\\Db\\": "src/MaxMind/Db"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Gregory J. Oschwald",
+                    "email": "goschwald@maxmind.com",
+                    "homepage": "https://www.maxmind.com/"
+                }
+            ],
+            "description": "MaxMind DB Reader API",
+            "homepage": "https://github.com/maxmind/MaxMind-DB-Reader-php",
+            "keywords": [
+                "database",
+                "geoip",
+                "geoip2",
+                "geolocation",
+                "maxmind"
+            ],
+            "support": {
+                "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
+                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.13.1"
+            },
+            "time": "2025-11-21T22:24:26+00:00"
         },
         {
             "name": "psr/http-client",
@@ -757,6 +822,57 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3019,5 +3135,5 @@
         "php": ">=8.1 <8.6"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/API/Authentication/ApiKeyAuthentication.php
+++ b/src/API/Authentication/ApiKeyAuthentication.php
@@ -18,9 +18,19 @@ class ApiKeyAuthentication implements AuthenticationInterface {
     protected string $apiKey;
     protected string $headerName;
 
-    public function __construct(string $apiKey, string $headerName = 'X-API-Key') {
+    public function __construct(#[\SensitiveParameter] string $apiKey, string $headerName = 'X-API-Key') {
         $this->apiKey = $apiKey;
         $this->headerName = $headerName;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array {
+        return [
+            'apiKey' => $this->apiKey === '' ? '' : '[redacted]',
+            'headerName' => $this->headerName,
+        ];
     }
 
     public function getAuthHeaders(): array {
@@ -41,7 +51,7 @@ class ApiKeyAuthentication implements AuthenticationInterface {
         return $this->apiKey;
     }
 
-    public function setApiKey(string $apiKey): void {
+    public function setApiKey(#[\SensitiveParameter] string $apiKey): void {
         $this->apiKey = $apiKey;
     }
 

--- a/src/API/Authentication/ApiKeyAuthentication.php
+++ b/src/API/Authentication/ApiKeyAuthentication.php
@@ -17,10 +17,16 @@ use APIToolkit\Contracts\Interfaces\API\AuthenticationInterface;
 class ApiKeyAuthentication implements AuthenticationInterface {
     protected string $apiKey;
     protected string $headerName;
+    /** @var array<string, string> */
+    protected array $additionalHeaders;
 
-    public function __construct(#[\SensitiveParameter] string $apiKey, string $headerName = 'X-API-Key') {
+    /**
+     * @param array<string, string> $additionalHeaders Optional additional headers to include
+     */
+    public function __construct(#[\SensitiveParameter] string $apiKey, string $headerName = 'X-API-Key', array $additionalHeaders = []) {
         $this->apiKey = $apiKey;
         $this->headerName = $headerName;
+        $this->additionalHeaders = $additionalHeaders;
     }
 
     /**
@@ -30,13 +36,29 @@ class ApiKeyAuthentication implements AuthenticationInterface {
         return [
             'apiKey' => $this->apiKey === '' ? '' : '[redacted]',
             'headerName' => $this->headerName,
+            'additionalHeaders' => $this->additionalHeaders,
         ];
     }
 
     public function getAuthHeaders(): array {
-        return [
-            $this->headerName => $this->apiKey,
-        ];
+        return array_merge(
+            [$this->headerName => $this->apiKey],
+            $this->additionalHeaders
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAdditionalHeaders(): array {
+        return $this->additionalHeaders;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function setAdditionalHeaders(array $headers): void {
+        $this->additionalHeaders = $headers;
     }
 
     public function getType(): string {

--- a/src/API/Authentication/BasicAuthentication.php
+++ b/src/API/Authentication/BasicAuthentication.php
@@ -17,10 +17,16 @@ use APIToolkit\Contracts\Interfaces\API\AuthenticationInterface;
 class BasicAuthentication implements AuthenticationInterface {
     protected string $username;
     protected string $password;
+    /** @var array<string, string> */
+    protected array $additionalHeaders;
 
-    public function __construct(string $username, #[\SensitiveParameter] string $password) {
+    /**
+     * @param array<string, string> $additionalHeaders Optional additional headers to include
+     */
+    public function __construct(string $username, #[\SensitiveParameter] string $password, array $additionalHeaders = []) {
         $this->username = $username;
         $this->password = $password;
+        $this->additionalHeaders = $additionalHeaders;
     }
 
     /**
@@ -30,14 +36,31 @@ class BasicAuthentication implements AuthenticationInterface {
         return [
             'username' => $this->username,
             'password' => $this->password === '' ? '' : '[redacted]',
+            'additionalHeaders' => $this->additionalHeaders,
         ];
     }
 
     public function getAuthHeaders(): array {
         $credentials = base64_encode($this->username . ':' . $this->password);
-        return [
-            'Authorization' => 'Basic ' . $credentials,
-        ];
+
+        return array_merge(
+            ['Authorization' => 'Basic ' . $credentials],
+            $this->additionalHeaders
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAdditionalHeaders(): array {
+        return $this->additionalHeaders;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function setAdditionalHeaders(array $headers): void {
+        $this->additionalHeaders = $headers;
     }
 
     public function getType(): string {

--- a/src/API/Authentication/BasicAuthentication.php
+++ b/src/API/Authentication/BasicAuthentication.php
@@ -18,9 +18,19 @@ class BasicAuthentication implements AuthenticationInterface {
     protected string $username;
     protected string $password;
 
-    public function __construct(string $username, string $password) {
+    public function __construct(string $username, #[\SensitiveParameter] string $password) {
         $this->username = $username;
         $this->password = $password;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array {
+        return [
+            'username' => $this->username,
+            'password' => $this->password === '' ? '' : '[redacted]',
+        ];
     }
 
     public function getAuthHeaders(): array {
@@ -46,7 +56,7 @@ class BasicAuthentication implements AuthenticationInterface {
         $this->username = $username;
     }
 
-    public function setPassword(string $password): void {
+    public function setPassword(#[\SensitiveParameter] string $password): void {
         $this->password = $password;
     }
 }

--- a/src/API/Authentication/BearerAuthentication.php
+++ b/src/API/Authentication/BearerAuthentication.php
@@ -23,9 +23,19 @@ class BearerAuthentication implements AuthenticationInterface {
      * @param string $token The bearer token
      * @param array<string, string> $additionalHeaders Optional additional headers to include
      */
-    public function __construct(string $token, array $additionalHeaders = []) {
+    public function __construct(#[\SensitiveParameter] string $token, array $additionalHeaders = []) {
         $this->token = $token;
         $this->additionalHeaders = $additionalHeaders;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array {
+        return [
+            'token' => $this->token === '' ? '' : '[redacted]',
+            'additionalHeaders' => $this->additionalHeaders,
+        ];
     }
 
     public function getAuthHeaders(): array {
@@ -47,7 +57,7 @@ class BearerAuthentication implements AuthenticationInterface {
         return $this->token;
     }
 
-    public function setToken(string $token): void {
+    public function setToken(#[\SensitiveParameter] string $token): void {
         $this->token = $token;
     }
 

--- a/src/API/Authentication/HmacAuthentication.php
+++ b/src/API/Authentication/HmacAuthentication.php
@@ -1,0 +1,117 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : HmacAuthentication.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Authentication;
+
+use APIToolkit\Contracts\Interfaces\API\RequestAwareAuthenticationInterface;
+use InvalidArgumentException;
+
+/**
+ * Per-request HMAC request signing — a shipped implementation of
+ * RequestAwareAuthenticationInterface.
+ *
+ * For each request a signature is computed over a canonical string made of the
+ * HTTP method, the request URI, a timestamp and a hash of the body:
+ *
+ *   {METHOD}\n{URI}\n{timestamp}\n{sha256(body)}
+ *
+ * and sent alongside the key id and timestamp in configurable headers. The
+ * timestamp lets the server reject replays; the body hash binds the signature
+ * to the payload.
+ */
+class HmacAuthentication implements RequestAwareAuthenticationInterface {
+    private string $keyId;
+    private string $secret;
+    private string $algorithm;
+    private string $signatureHeader;
+    private string $timestampHeader;
+    private string $keyIdHeader;
+
+    /**
+     * @param string $keyId Public key/credential id sent with each request
+     * @param string $secret Shared secret used for the HMAC (never transmitted)
+     * @param string $algorithm HMAC hash algorithm (default sha256)
+     * @param string $signatureHeader Header carrying the signature
+     * @param string $timestampHeader Header carrying the request timestamp
+     * @param string $keyIdHeader Header carrying the key id
+     */
+    public function __construct(
+        string $keyId,
+        #[\SensitiveParameter]
+        string $secret,
+        string $algorithm = 'sha256',
+        string $signatureHeader = 'X-Signature',
+        string $timestampHeader = 'X-Timestamp',
+        string $keyIdHeader = 'X-Key-Id'
+    ) {
+        if (!in_array($algorithm, hash_hmac_algos(), true)) {
+            throw new InvalidArgumentException("Unsupported HMAC algorithm: {$algorithm}");
+        }
+
+        $this->keyId = $keyId;
+        $this->secret = $secret;
+        $this->algorithm = $algorithm;
+        $this->signatureHeader = $signatureHeader;
+        $this->timestampHeader = $timestampHeader;
+        $this->keyIdHeader = $keyIdHeader;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAuthHeadersFor(string $method, string $uri, ?string $body = null): array {
+        return $this->sign($method, $uri, $body, time());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAuthHeaders(): array {
+        // Non-request-aware fallback: sign an empty canonical request. Prefer
+        // getAuthHeadersFor(), which ClientAbstract calls automatically.
+        return $this->sign('', '', null, time());
+    }
+
+    public function getType(): string {
+        return 'HMAC';
+    }
+
+    public function isValid(): bool {
+        return $this->keyId !== '' && $this->secret !== '';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function sign(string $method, string $uri, ?string $body, int $timestamp): array {
+        $bodyHash = hash('sha256', $body ?? '');
+        $canonical = strtoupper($method) . "\n" . $uri . "\n" . $timestamp . "\n" . $bodyHash;
+        $signature = hash_hmac($this->algorithm, $canonical, $this->secret);
+
+        return [
+            $this->keyIdHeader => $this->keyId,
+            $this->timestampHeader => (string) $timestamp,
+            $this->signatureHeader => $signature,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array {
+        return [
+            'keyId' => $this->keyId,
+            'secret' => $this->secret === '' ? '' : '[redacted]',
+            'algorithm' => $this->algorithm,
+        ];
+    }
+}

--- a/src/API/Authentication/OAuth2/EncryptedFileTokenStore.php
+++ b/src/API/Authentication/OAuth2/EncryptedFileTokenStore.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : EncryptedFileTokenStore.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Authentication\OAuth2;
+
+use CommonToolkit\Helper\Data\CryptoHelper;
+use RuntimeException;
+use Throwable;
+
+/**
+ * File token store that encrypts the token at rest with AES-256-GCM.
+ *
+ * The token JSON is authenticated-encrypted (via CommonToolkit\CryptoHelper)
+ * under a caller-supplied 32-byte key before it is written, so a leaked token
+ * file does not expose the access/refresh tokens. A tampered or wrong-key file
+ * fails the authentication tag and is treated as "no token".
+ */
+class EncryptedFileTokenStore extends FileTokenStore {
+    private string $key;
+
+    /**
+     * @param string $path Storage path
+     * @param string $key  32-byte encryption key (AES-256). Use
+     *                     CryptoHelper::generateKey(32) and keep it in your
+     *                     secret store; a base64 key is decoded automatically.
+     */
+    public function __construct(string $path, #[\SensitiveParameter] string $key) {
+        parent::__construct($path);
+
+        $binaryKey = self::normalizeKey($key);
+        if (strlen($binaryKey) !== 32) {
+            throw new RuntimeException('Encryption key must be 32 bytes (AES-256)');
+        }
+        $this->key = $binaryKey;
+    }
+
+    public function load(): ?OAuth2Token {
+        if (!is_file($this->path)) {
+            return null;
+        }
+
+        $raw = @file_get_contents($this->path);
+        if ($raw === false || $raw === '') {
+            return null;
+        }
+
+        $envelope = json_decode($raw, true);
+        if (!is_array($envelope)) {
+            return null;
+        }
+
+        try {
+            $plaintext = CryptoHelper::decrypt($envelope, $this->key);
+        } catch (Throwable) {
+            // Wrong key or tampered file → treat as no usable token.
+            return null;
+        }
+
+        $data = json_decode($plaintext, true);
+        if (!is_array($data)) {
+            return null;
+        }
+
+        return OAuth2Token::fromArray($data);
+    }
+
+    public function save(OAuth2Token $token): void {
+        $envelope = CryptoHelper::encrypt((string) json_encode($token->toArray()), $this->key);
+        $this->writeAtomic((string) json_encode($envelope));
+    }
+
+    private static function normalizeKey(string $key): string {
+        if (strlen($key) === 32) {
+            return $key;
+        }
+
+        $decoded = base64_decode($key, true);
+
+        return $decoded !== false && strlen($decoded) === 32 ? $decoded : $key;
+    }
+}

--- a/src/API/Authentication/OAuth2/FileTokenStore.php
+++ b/src/API/Authentication/OAuth2/FileTokenStore.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : FileTokenStore.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Authentication\OAuth2;
+
+use APIToolkit\Contracts\Interfaces\API\OAuth2TokenStoreInterface;
+use RuntimeException;
+
+/**
+ * Persists an OAuth2 token as JSON in a single file.
+ *
+ * The file is created with 0600 permissions and written atomically (temp file
+ * + rename) so a concurrent reader never sees a half-written token. Suitable
+ * for CLI tools and single-host machine-to-machine clients; for multi-host or
+ * multi-tenant setups use an application-side store or {@see Psr16TokenStore}.
+ */
+class FileTokenStore implements OAuth2TokenStoreInterface {
+    protected string $path;
+
+    public function __construct(string $path) {
+        if ($path === '') {
+            throw new RuntimeException('Token store path must not be empty');
+        }
+        $this->path = $path;
+    }
+
+    public function load(): ?OAuth2Token {
+        if (!is_file($this->path)) {
+            return null;
+        }
+
+        $raw = @file_get_contents($this->path);
+        if ($raw === false || $raw === '') {
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            return null;
+        }
+
+        return OAuth2Token::fromArray($data);
+    }
+
+    public function save(OAuth2Token $token): void {
+        $this->writeAtomic((string) json_encode($token->toArray()));
+    }
+
+    public function clear(): void {
+        if (is_file($this->path)) {
+            @unlink($this->path);
+        }
+    }
+
+    protected function writeAtomic(string $contents): void {
+        $dir = dirname($this->path);
+        if (!is_dir($dir) && !@mkdir($dir, 0700, true) && !is_dir($dir)) {
+            throw new RuntimeException("Cannot create token store directory: {$dir}");
+        }
+
+        $tmp = @tempnam($dir, '.tok');
+        if ($tmp === false) {
+            throw new RuntimeException("Cannot create temp file in: {$dir}");
+        }
+
+        @chmod($tmp, 0600);
+        if (@file_put_contents($tmp, $contents, LOCK_EX) === false || !@rename($tmp, $this->path)) {
+            @unlink($tmp);
+            throw new RuntimeException("Cannot write token store file: {$this->path}");
+        }
+
+        @chmod($this->path, 0600);
+    }
+}

--- a/src/API/Authentication/OAuth2/OAuth2AuthorizationCodeGrant.php
+++ b/src/API/Authentication/OAuth2/OAuth2AuthorizationCodeGrant.php
@@ -51,15 +51,17 @@ class OAuth2AuthorizationCodeGrant extends OAuth2GrantAbstract {
         ?LoggerInterface $logger = null,
         ?HttpClient $httpClient = null
     ) {
-        if ($clientId === '' || $clientSecret === '') {
-            throw new InvalidArgumentException('Client id and client secret must not be empty');
-        }
-        if ($authorizeUrl === '' || $tokenUrl === '') {
-            throw new InvalidArgumentException('Authorize URL and token URL must not be empty');
+        if ($authorizeUrl === '') {
+            throw new InvalidArgumentException('Authorize URL must not be empty');
         }
 
+        // clientId and tokenUrl are validated by the parent constructor. An
+        // empty client secret is allowed here so public (PKCE) clients can use
+        // the authorization-code flow; the secret is only required by the
+        // client_secret_post/basic auth methods (see requireClientSecret()).
         parent::__construct($clientId, $clientSecret, $tokenUrl, $logger, $httpClient);
 
+        $this->allowEmptyClientSecret = true;
         $this->authorizeUrl = $authorizeUrl;
         $this->redirectUri = $redirectUri;
     }

--- a/src/API/Authentication/OAuth2/OAuth2ClientCredentialsAuthentication.php
+++ b/src/API/Authentication/OAuth2/OAuth2ClientCredentialsAuthentication.php
@@ -38,6 +38,8 @@ class OAuth2ClientCredentialsAuthentication implements RefreshableAuthentication
     protected int $expiryLeeway;
     /** @var array<string, string> */
     protected array $additionalHeaders;
+    /** @var array<string, string> */
+    protected array $additionalTokenParams;
 
     /**
      * @param OAuth2ClientCredentialsGrant $grant Grant used to fetch tokens
@@ -45,19 +47,22 @@ class OAuth2ClientCredentialsAuthentication implements RefreshableAuthentication
      * @param array<int, string> $scopes Scopes requested with every token fetch
      * @param int $expiryLeeway Seconds before actual expiry a token is treated as expired
      * @param array<string, string> $additionalHeaders Optional additional headers to include
+     * @param array<string, string> $additionalTokenParams Extra provider-specific form params sent with every token request (e.g. ['audience' => '...'])
      */
     public function __construct(
         OAuth2ClientCredentialsGrant $grant,
         ?OAuth2TokenStoreInterface $tokenStore = null,
         array $scopes = [],
         int $expiryLeeway = 60,
-        array $additionalHeaders = []
+        array $additionalHeaders = [],
+        array $additionalTokenParams = []
     ) {
         $this->grant = $grant;
         $this->tokenStore = $tokenStore ?? new InMemoryTokenStore;
         $this->scopes = $scopes;
         $this->expiryLeeway = $expiryLeeway;
         $this->additionalHeaders = $additionalHeaders;
+        $this->additionalTokenParams = $additionalTokenParams;
     }
 
     public function getAuthHeaders(): array {
@@ -93,7 +98,7 @@ class OAuth2ClientCredentialsAuthentication implements RefreshableAuthentication
         $this->tokenStore->clear();
 
         try {
-            $token = $this->grant->fetchToken($this->scopes);
+            $token = $this->grant->fetchToken($this->scopes, $this->additionalTokenParams);
         } catch (ApiException) {
             return false;
         }
@@ -113,7 +118,7 @@ class OAuth2ClientCredentialsAuthentication implements RefreshableAuthentication
             return $token;
         }
 
-        $token = $this->grant->fetchToken($this->scopes);
+        $token = $this->grant->fetchToken($this->scopes, $this->additionalTokenParams);
         $this->tokenStore->save($token);
 
         return $token;

--- a/src/API/Authentication/OAuth2/OAuth2DeviceCodeGrant.php
+++ b/src/API/Authentication/OAuth2/OAuth2DeviceCodeGrant.php
@@ -1,0 +1,149 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : OAuth2DeviceCodeGrant.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Authentication\OAuth2;
+
+use APIToolkit\Exceptions\{ApiException, BadRequestException};
+use GuzzleHttp\Client as HttpClient;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Provider-neutral OAuth2 Device Authorization Grant (RFC 8628).
+ *
+ * The standard flow for headless/CLI tools and input-constrained devices:
+ * request a device + user code, show the user a verification URL, then poll
+ * the token endpoint until the user approves (or the request expires).
+ *
+ * Token endpoint mechanics (client authentication, error mapping, throttling,
+ * retries) are shared via OAuth2GrantAbstract.
+ */
+class OAuth2DeviceCodeGrant extends OAuth2GrantAbstract {
+    protected string $deviceAuthorizationUrl;
+
+    /**
+     * @param string $clientId OAuth2 client id
+     * @param string $clientSecret Client secret (may be empty for public device clients)
+     * @param string $deviceAuthorizationUrl Full device authorization endpoint URL
+     * @param string $tokenUrl Full token endpoint URL
+     * @param LoggerInterface|null $logger PSR-3 logger instance
+     * @param HttpClient|null $httpClient Optional pre-configured Guzzle client (e.g. MockHandler in tests)
+     */
+    public function __construct(
+        string $clientId,
+        #[\SensitiveParameter]
+        string $clientSecret,
+        string $deviceAuthorizationUrl,
+        string $tokenUrl,
+        ?LoggerInterface $logger = null,
+        ?HttpClient $httpClient = null
+    ) {
+        if ($deviceAuthorizationUrl === '') {
+            throw new InvalidArgumentException('Device authorization URL must not be empty');
+        }
+
+        parent::__construct($clientId, $clientSecret, $tokenUrl, $logger, $httpClient);
+
+        // Device clients are frequently public (no secret).
+        $this->allowEmptyClientSecret = true;
+        $this->deviceAuthorizationUrl = $deviceAuthorizationUrl;
+    }
+
+    /**
+     * Request a device + user code (RFC 8628 section 3.1/3.2).
+     *
+     * @param array<int, string> $scopes Requested scopes
+     * @return array{device_code: string, user_code: string, verification_uri: string, verification_uri_complete?: string, expires_in: int, interval: int} Decoded device authorization response
+     */
+    public function requestDeviceCode(array $scopes = []): array {
+        $params = ['client_id' => $this->clientId];
+        if ($scopes !== []) {
+            $params['scope'] = implode(' ', $scopes);
+        }
+
+        $response = $this->post($this->deviceAuthorizationUrl, [
+            'form_params' => $params,
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        $payload = json_decode((string) $response->getBody(), true);
+        if (!is_array($payload) || !isset($payload['device_code'], $payload['user_code'])) {
+            throw new ApiException('Device authorization endpoint returned an unexpected payload', $response->getStatusCode(), $response);
+        }
+
+        // Normalize the poll interval (RFC 8628 default is 5 seconds).
+        $payload['interval'] = isset($payload['interval']) && is_numeric($payload['interval']) ? (int) $payload['interval'] : 5;
+        $payload['expires_in'] = isset($payload['expires_in']) && is_numeric($payload['expires_in']) ? (int) $payload['expires_in'] : 0;
+
+        return $payload;
+    }
+
+    /**
+     * Exchange an approved device code for a token — a single token request.
+     *
+     * @throws BadRequestException while the authorization is still pending
+     *                             (error=authorization_pending / slow_down)
+     */
+    public function exchangeDeviceCode(string $deviceCode): OAuth2Token {
+        if ($deviceCode === '') {
+            throw new InvalidArgumentException('Device code must not be empty');
+        }
+
+        return $this->requestToken([
+            'grant_type' => 'urn:ietf:params:oauth:grant-type:device_code',
+            'device_code' => $deviceCode,
+        ]);
+    }
+
+    /**
+     * Poll the token endpoint until the user approves the device (or it times
+     * out). Honours the server's authorization_pending / slow_down responses.
+     *
+     * @param string $deviceCode Device code from requestDeviceCode()
+     * @param int $interval Poll interval in seconds (RFC 8628 minimum is 5)
+     * @param int|null $expiresIn Optional overall timeout in seconds
+     */
+    public function pollForToken(string $deviceCode, int $interval = 5, ?int $expiresIn = null): OAuth2Token {
+        $interval = max(1, $interval);
+        $deadline = $expiresIn !== null ? time() + $expiresIn : null;
+
+        while (true) {
+            try {
+                return $this->exchangeDeviceCode($deviceCode);
+            } catch (BadRequestException $e) {
+                $error = $e->getErrorCode();
+                if ($error === 'slow_down') {
+                    $interval += 5;
+                } elseif ($error !== 'authorization_pending') {
+                    // access_denied, expired_token, invalid_grant, …
+                    throw $e;
+                }
+            }
+
+            if ($deadline !== null && time() >= $deadline) {
+                throw new RuntimeException('Device authorization timed out before the user approved the request');
+            }
+
+            $this->wait($interval);
+        }
+    }
+
+    /**
+     * Sleep between poll attempts. Overridable so tests can poll without delay.
+     */
+    protected function wait(int $seconds): void {
+        if ($seconds > 0) {
+            sleep($seconds);
+        }
+    }
+}

--- a/src/API/Authentication/OAuth2/OAuth2GrantAbstract.php
+++ b/src/API/Authentication/OAuth2/OAuth2GrantAbstract.php
@@ -50,6 +50,14 @@ abstract class OAuth2GrantAbstract extends ClientAbstract {
     protected int $assertionLifetime = 300;
 
     /**
+     * Whether an empty client secret is acceptable for client_secret_post
+     * (public/PKCE clients). Confidential grants (client credentials) keep this
+     * false so a missing secret is rejected; the authorization-code grant sets
+     * it true.
+     */
+    protected bool $allowEmptyClientSecret = false;
+
+    /**
      * @param string $clientId OAuth2 client id
      * @param string $clientSecret OAuth2 client secret; may be empty only when
      *                             the grant authenticates via setPrivateKeyJwt()
@@ -185,8 +193,14 @@ abstract class OAuth2GrantAbstract extends ClientAbstract {
             $params['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
             $params['client_assertion'] = $this->buildClientAssertion();
         } else {
+            // client_secret_post. A public (PKCE) client has no secret and
+            // sends only client_id; a confidential client must provide one.
             $params['client_id'] = $this->clientId;
-            $params['client_secret'] = $this->requireClientSecret();
+            if ($this->clientSecret !== '') {
+                $params['client_secret'] = $this->clientSecret;
+            } elseif (!$this->allowEmptyClientSecret) {
+                $params['client_secret'] = $this->requireClientSecret();
+            }
         }
 
         return [

--- a/src/API/Authentication/OAuth2/OAuth2GrantAbstract.php
+++ b/src/API/Authentication/OAuth2/OAuth2GrantAbstract.php
@@ -59,6 +59,7 @@ abstract class OAuth2GrantAbstract extends ClientAbstract {
      */
     public function __construct(
         string $clientId,
+        #[\SensitiveParameter]
         string $clientSecret,
         string $tokenUrl,
         ?LoggerInterface $logger = null,
@@ -79,6 +80,26 @@ abstract class OAuth2GrantAbstract extends ClientAbstract {
 
     public function getClientId(): string {
         return $this->clientId;
+    }
+
+    /**
+     * Keep credentials out of var_dump()/print_r()/DI-container dumps and
+     * crash reporters. #[\SensitiveParameter] already masks them in stack
+     * traces; this covers the reflection/serialization dump paths.
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array {
+        return [
+            'clientId' => $this->clientId,
+            'clientSecret' => $this->clientSecret === '' ? '' : '[redacted]',
+            'tokenAuthMethod' => $this->tokenAuthMethod,
+            'assertionPrivateKey' => $this->assertionPrivateKey === null ? null : '[redacted]',
+            'assertionPassphrase' => $this->assertionPassphrase === null ? null : '[redacted]',
+            'assertionCertificate' => $this->assertionCertificate,
+            'assertionLifetime' => $this->assertionLifetime,
+            'baseUrl' => $this->baseUrl,
+        ];
     }
 
     /**
@@ -112,7 +133,7 @@ abstract class OAuth2GrantAbstract extends ClientAbstract {
      * @param string|null $passphrase Passphrase of the private key, if any
      * @param int $assertionLifetime Assertion validity in seconds (default 300)
      */
-    public function setPrivateKeyJwt(string $privateKeyPem, ?string $certificatePem = null, ?string $passphrase = null, int $assertionLifetime = 300): void {
+    public function setPrivateKeyJwt(#[\SensitiveParameter] string $privateKeyPem, ?string $certificatePem = null, #[\SensitiveParameter] ?string $passphrase = null, int $assertionLifetime = 300): void {
         if ($privateKeyPem === '') {
             throw new InvalidArgumentException('Private key must not be empty');
         }

--- a/src/API/Authentication/OAuth2/Psr16TokenStore.php
+++ b/src/API/Authentication/OAuth2/Psr16TokenStore.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : Psr16TokenStore.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Authentication\OAuth2;
+
+use APIToolkit\Contracts\Interfaces\API\OAuth2TokenStoreInterface;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * OAuth2 token store backed by any PSR-16 cache (Redis, Memcached, APCu, …).
+ *
+ * Enables sharing a token across processes/hosts. The cache key defaults to
+ * "oauth2_token" but should be namespaced per tenant/client when a cache is
+ * shared. The token is stored as its toArray() JSON.
+ */
+class Psr16TokenStore implements OAuth2TokenStoreInterface {
+    private CacheInterface $cache;
+    private string $key;
+
+    public function __construct(CacheInterface $cache, string $key = 'oauth2_token') {
+        $this->cache = $cache;
+        $this->key = $key;
+    }
+
+    public function load(): ?OAuth2Token {
+        $raw = $this->cache->get($this->key);
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            return null;
+        }
+
+        return OAuth2Token::fromArray($data);
+    }
+
+    public function save(OAuth2Token $token): void {
+        // Expire the cache entry a little after the token itself so a stale
+        // entry is never served; tokens without expiry are cached without TTL.
+        $ttl = null;
+        $expiresAt = $token->getExpiresAt();
+        if ($expiresAt !== null) {
+            $ttl = max(1, $expiresAt->getTimestamp() - time() + 60);
+        }
+
+        $this->cache->set($this->key, (string) json_encode($token->toArray()), $ttl);
+    }
+
+    public function clear(): void {
+        $this->cache->delete($this->key);
+    }
+}

--- a/src/API/Cache/Psr16ResponseCache.php
+++ b/src/API/Cache/Psr16ResponseCache.php
@@ -1,0 +1,158 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : Psr16ResponseCache.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Cache;
+
+use APIToolkit\Contracts\Abstracts\API\ClientAbstract;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Transparent GET response cache with conditional requests, backed by any
+ * PSR-16 cache. Registers itself on a client's middleware hooks:
+ *
+ *   (new Psr16ResponseCache($cache))->register($client);
+ *
+ * Behaviour per GET:
+ *  - a still-fresh cached entry (within $ttl) is served without a network call;
+ *  - a stale entry with an ETag/Last-Modified triggers a conditional request
+ *    (If-None-Match / If-Modified-Since); a 304 is served from cache and its
+ *    freshness renewed, a 200 refreshes the stored body and validators.
+ *
+ * Only GET is cached, and only 200 responses are stored.
+ */
+class Psr16ResponseCache {
+    private CacheInterface $cache;
+    private int $ttl;
+    private string $prefix;
+
+    /**
+     * @param int $ttl Freshness window in seconds for serving without revalidation
+     */
+    public function __construct(CacheInterface $cache, int $ttl = 60, string $prefix = 'httpcache_') {
+        $this->cache = $cache;
+        $this->ttl = max(0, $ttl);
+        $this->prefix = $prefix;
+    }
+
+    public function register(ClientAbstract $client): void {
+        $client->onRequest([$this, 'onRequest']);
+        $client->onResponse([$this, 'onResponse']);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>|ResponseInterface
+     */
+    public function onRequest(string $method, string $uri, array $options): array|ResponseInterface {
+        if (strtoupper($method) !== 'GET') {
+            return $options;
+        }
+
+        $entry = $this->load($uri);
+        if ($entry === null) {
+            return $options;
+        }
+
+        if (isset($entry['stored_at']) && (time() - (int) $entry['stored_at']) < $this->ttl) {
+            // Still fresh: serve from cache without a network round-trip.
+            return $this->toResponse($entry);
+        }
+
+        // Stale but revalidatable: attach conditional-request headers.
+        $headers = $options['headers'] ?? [];
+        if (($entry['etag'] ?? '') !== '') {
+            $headers['If-None-Match'] = $entry['etag'];
+        }
+        if (($entry['last_modified'] ?? '') !== '') {
+            $headers['If-Modified-Since'] = $entry['last_modified'];
+        }
+        $options['headers'] = $headers;
+
+        return $options;
+    }
+
+    public function onResponse(ResponseInterface $response, string $method, string $uri): ResponseInterface {
+        if (strtoupper($method) !== 'GET') {
+            return $response;
+        }
+
+        $status = $response->getStatusCode();
+
+        if ($status === 304) {
+            $entry = $this->load($uri);
+            if ($entry !== null) {
+                $entry['stored_at'] = time();
+                $this->store($uri, $entry); // renew freshness
+                return $this->toResponse($entry);
+            }
+
+            return $response;
+        }
+
+        if ($status === 200) {
+            $this->store($uri, [
+                'body' => (string) $response->getBody(),
+                'etag' => $response->getHeaderLine('ETag'),
+                'last_modified' => $response->getHeaderLine('Last-Modified'),
+                'content_type' => $response->getHeaderLine('Content-Type'),
+                'stored_at' => time(),
+            ]);
+            if ($response->getBody()->isSeekable()) {
+                $response->getBody()->rewind();
+            }
+        }
+
+        return $response;
+    }
+
+    private function key(string $uri): string {
+        return $this->prefix . hash('sha256', $uri);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function load(string $uri): ?array {
+        $raw = $this->cache->get($this->key($uri));
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : null;
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    private function store(string $uri, array $entry): void {
+        // Keep the entry around a bit past its freshness so revalidation stays
+        // possible (validators outlive the fresh window).
+        $this->cache->set($this->key($uri), (string) json_encode($entry), $this->ttl > 0 ? $this->ttl * 10 : null);
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    private function toResponse(array $entry): ResponseInterface {
+        $headers = [];
+        if (($entry['content_type'] ?? '') !== '') {
+            $headers['Content-Type'] = $entry['content_type'];
+        }
+        $headers['X-Cache'] = 'HIT';
+
+        return new Response(200, $headers, (string) ($entry['body'] ?? ''));
+    }
+}

--- a/src/API/Pagination/CursorPaginator.php
+++ b/src/API/Pagination/CursorPaginator.php
@@ -74,6 +74,7 @@ class CursorPaginator implements IteratorAggregate {
     public function pages(): Generator {
         $cursor = null;
         $pageCount = 0;
+        $seenCursors = [];
 
         do {
             $page = ($this->pageFetcher)($cursor);
@@ -85,10 +86,17 @@ class CursorPaginator implements IteratorAggregate {
             yield $page;
 
             $pageCount++;
+
+            if ($cursor !== null) {
+                $seenCursors[$cursor] = true;
+            }
+
             $nextCursor = $page->getNextCursor();
 
-            if ($nextCursor !== null && $nextCursor === $cursor) {
-                throw new RuntimeException('Pagination cursor did not advance — aborting to avoid an endless loop.');
+            // Abort on any cursor we have already visited, not just an
+            // immediate repeat — this also catches longer A→B→A cycles.
+            if ($nextCursor !== null && isset($seenCursors[$nextCursor])) {
+                throw new RuntimeException('Pagination cursor repeated — aborting to avoid an endless loop.');
             }
 
             $cursor = $nextCursor;

--- a/src/API/Pagination/LinkHeaderPaginator.php
+++ b/src/API/Pagination/LinkHeaderPaginator.php
@@ -1,0 +1,113 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : LinkHeaderPaginator.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Pagination;
+
+use Closure;
+use Generator;
+use InvalidArgumentException;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Transparently iterates API results paginated via RFC 8288 Link headers
+ * (e.g. GitHub-style `Link: <…?page=2>; rel="next", <…?page=9>; rel="last"`).
+ *
+ * The page fetcher is invoked with the next URL to load (null for the first
+ * page) and returns the PSR-7 response; an items extractor pulls the item list
+ * out of that response. Iteration follows the `rel="next"` link until it is
+ * absent.
+ *
+ * Example:
+ *
+ *   $paginator = new LinkHeaderPaginator(
+ *       fn (?string $url) => $client->get($url ?? '/repos/acme/app/issues?per_page=100'),
+ *       fn ($response) => json_decode((string) $response->getBody(), true) ?: []
+ *   );
+ *   foreach ($paginator as $issue) { ... }
+ *
+ * @implements IteratorAggregate<int, mixed>
+ */
+class LinkHeaderPaginator implements IteratorAggregate {
+    protected Closure $pageFetcher;
+    protected Closure $itemsExtractor;
+    protected ?int $maxPages;
+
+    /**
+     * @param callable(?string): ResponseInterface $pageFetcher Loads the given URL (null = first page)
+     * @param callable(ResponseInterface): array<int, mixed> $itemsExtractor Extracts the item list from a response
+     * @param int|null $maxPages Optional hard limit on the number of fetched pages
+     */
+    public function __construct(callable $pageFetcher, callable $itemsExtractor, ?int $maxPages = null) {
+        if ($maxPages !== null && $maxPages < 1) {
+            throw new InvalidArgumentException('Max pages must be at least 1');
+        }
+
+        $this->pageFetcher = Closure::fromCallable($pageFetcher);
+        $this->itemsExtractor = Closure::fromCallable($itemsExtractor);
+        $this->maxPages = $maxPages;
+    }
+
+    /**
+     * @return Generator<int, mixed>
+     */
+    public function getIterator(): Generator {
+        foreach ($this->pages() as $items) {
+            foreach ($items as $item) {
+                yield $item;
+            }
+        }
+    }
+
+    /**
+     * @return Generator<int, array<int, mixed>>
+     */
+    public function pages(): Generator {
+        $url = null;
+        $fetched = 0;
+
+        do {
+            $response = ($this->pageFetcher)($url);
+            yield array_values(($this->itemsExtractor)($response));
+
+            $fetched++;
+            $url = self::parseNextLink($response->getHeaderLine('Link'));
+        } while ($url !== null && ($this->maxPages === null || $fetched < $this->maxPages));
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function toArray(): array {
+        return iterator_to_array($this, false);
+    }
+
+    /**
+     * Extract the rel="next" target from an RFC 8288 Link header, or null.
+     */
+    public static function parseNextLink(string $linkHeader): ?string {
+        if ($linkHeader === '') {
+            return null;
+        }
+
+        foreach (explode(',', $linkHeader) as $part) {
+            if (preg_match('/<\s*([^>]+)\s*>\s*;\s*(.+)/', trim($part), $m) !== 1) {
+                continue;
+            }
+            if (preg_match('/rel\s*=\s*"?\s*next\s*"?/i', $m[2]) === 1) {
+                return trim($m[1]);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/API/Pagination/OffsetPaginator.php
+++ b/src/API/Pagination/OffsetPaginator.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : OffsetPaginator.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Pagination;
+
+use Closure;
+use Generator;
+use InvalidArgumentException;
+use IteratorAggregate;
+
+/**
+ * Transparently iterates offset/page-number paginated API results.
+ *
+ * The page fetcher is invoked with the current 1-based page number and returns
+ * an array of that page's items. Iteration stops when a page returns fewer than
+ * $pageSize items (the last page), when an empty page is returned, or when the
+ * optional $maxPages limit is reached.
+ *
+ * Example:
+ *
+ *   $paginator = new OffsetPaginator(function (int $page) use ($client): array {
+ *       $data = json_decode((string) $client->get("/items?page={$page}&per_page=100")->getBody(), true);
+ *       return $data['results'] ?? [];
+ *   }, pageSize: 100);
+ *   foreach ($paginator as $item) { ... }
+ *
+ * @implements IteratorAggregate<int, mixed>
+ */
+class OffsetPaginator implements IteratorAggregate {
+    protected Closure $pageFetcher;
+    protected int $pageSize;
+    protected int $startPage;
+    protected ?int $maxPages;
+
+    /**
+     * @param callable(int): array<int, mixed> $pageFetcher Loads one page of items for the given page number
+     * @param int $pageSize Expected items per full page; a shorter page ends iteration
+     * @param int $startPage First page number (usually 1, some APIs use 0)
+     * @param int|null $maxPages Optional hard limit on the number of fetched pages
+     */
+    public function __construct(callable $pageFetcher, int $pageSize = 100, int $startPage = 1, ?int $maxPages = null) {
+        if ($pageSize < 1) {
+            throw new InvalidArgumentException('Page size must be at least 1');
+        }
+        if ($maxPages !== null && $maxPages < 1) {
+            throw new InvalidArgumentException('Max pages must be at least 1');
+        }
+
+        $this->pageFetcher = Closure::fromCallable($pageFetcher);
+        $this->pageSize = $pageSize;
+        $this->startPage = $startPage;
+        $this->maxPages = $maxPages;
+    }
+
+    /**
+     * @return Generator<int, mixed>
+     */
+    public function getIterator(): Generator {
+        foreach ($this->pages() as $items) {
+            foreach ($items as $item) {
+                yield $item;
+            }
+        }
+    }
+
+    /**
+     * Iterate page by page (each yield is one page's item array).
+     *
+     * @return Generator<int, array<int, mixed>>
+     */
+    public function pages(): Generator {
+        $page = $this->startPage;
+        $fetched = 0;
+
+        do {
+            $items = array_values(($this->pageFetcher)($page));
+
+            if ($items === []) {
+                break;
+            }
+
+            yield $items;
+
+            $fetched++;
+            $page++;
+
+            // A short page is the last page.
+            if (count($items) < $this->pageSize) {
+                break;
+            }
+        } while ($this->maxPages === null || $fetched < $this->maxPages);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function toArray(): array {
+        return iterator_to_array($this, false);
+    }
+}

--- a/src/API/PendingRequest.php
+++ b/src/API/PendingRequest.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : PendingRequest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API;
+
+use APIToolkit\Contracts\Interfaces\API\ApiClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Chainable, discoverable request builder that accumulates Guzzle options and
+ * lowers to the same options the client already understands.
+ *
+ *   $client->pending()
+ *       ->withHeader('Accept', 'application/json')
+ *       ->withQuery(['page' => 2])
+ *       ->withIdempotencyKey($key)
+ *       ->post('/charges');
+ */
+class PendingRequest {
+    private ApiClientInterface $client;
+    /** @var array<string, mixed> */
+    private array $options = [];
+
+    public function __construct(ApiClientInterface $client) {
+        $this->client = $client;
+    }
+
+    public function withHeader(string $name, string $value): self {
+        $this->options['headers'][$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function withHeaders(array $headers): self {
+        $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers);
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    public function withQuery(array $query): self {
+        $this->options['query'] = array_merge($this->options['query'] ?? [], $query);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int|string, mixed> $data
+     */
+    public function withJson(array $data): self {
+        $this->options['json'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $formParams
+     */
+    public function withFormParams(array $formParams): self {
+        $this->options['form_params'] = $formParams;
+
+        return $this;
+    }
+
+    public function withBody(string $body): self {
+        $this->options['body'] = $body;
+
+        return $this;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $parts Guzzle multipart parts
+     */
+    public function asMultipart(array $parts): self {
+        $this->options['multipart'] = $parts;
+
+        return $this;
+    }
+
+    public function withIdempotencyKey(string $key): self {
+        $this->options['idempotency_key'] = $key;
+
+        return $this;
+    }
+
+    public function timeout(float $seconds): self {
+        $this->options['timeout'] = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Escape hatch for any other Guzzle request option.
+     */
+    public function withOption(string $key, mixed $value): self {
+        $this->options[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array {
+        return $this->options;
+    }
+
+    public function get(string $uri): ResponseInterface {
+        return $this->client->get($uri, $this->options);
+    }
+
+    public function post(string $uri): ResponseInterface {
+        return $this->client->post($uri, $this->options);
+    }
+
+    public function put(string $uri): ResponseInterface {
+        return $this->client->put($uri, $this->options);
+    }
+
+    public function patch(string $uri): ResponseInterface {
+        return $this->client->patch($uri, $this->options);
+    }
+
+    public function delete(string $uri): ResponseInterface {
+        return $this->client->delete($uri, $this->options);
+    }
+}

--- a/src/API/RateLimit.php
+++ b/src/API/RateLimit.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : RateLimit.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API;
+
+use DateTimeImmutable;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Immutable snapshot of the rate-limit budget advertised by a response.
+ *
+ * Parses both the widespread `X-RateLimit-*` headers (GitHub-style; reset is a
+ * Unix timestamp) and the IETF `RateLimit-*` draft headers (reset is
+ * delta-seconds). Missing fields are null.
+ */
+class RateLimit {
+    public function __construct(
+        public readonly ?int $limit,
+        public readonly ?int $remaining,
+        public readonly ?DateTimeImmutable $resetAt,
+    ) {}
+
+    /**
+     * Build a RateLimit from a response, or null when no rate-limit headers
+     * are present.
+     */
+    public static function fromResponse(ResponseInterface $response): ?self {
+        $limit = self::header($response, ['x-ratelimit-limit', 'ratelimit-limit']);
+        $remaining = self::header($response, ['x-ratelimit-remaining', 'ratelimit-remaining']);
+        $reset = self::header($response, ['x-ratelimit-reset', 'ratelimit-reset']);
+
+        if ($limit === null && $remaining === null && $reset === null) {
+            return null;
+        }
+
+        return new self(
+            $limit !== null ? (int) $limit : null,
+            $remaining !== null ? (int) $remaining : null,
+            self::parseReset($reset),
+        );
+    }
+
+    /**
+     * Whether the advertised budget is exhausted (remaining is known and 0).
+     */
+    public function isExhausted(): bool {
+        return $this->remaining !== null && $this->remaining <= 0;
+    }
+
+    /**
+     * Seconds until the window resets (>= 0), or null when unknown.
+     */
+    public function secondsUntilReset(?int $now = null): ?int {
+        if ($this->resetAt === null) {
+            return null;
+        }
+
+        return max(0, $this->resetAt->getTimestamp() - ($now ?? time()));
+    }
+
+    /**
+     * @param array<int, string> $names
+     */
+    private static function header(ResponseInterface $response, array $names): ?string {
+        foreach ($names as $name) {
+            if ($response->hasHeader($name)) {
+                $value = trim($response->getHeaderLine($name));
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function parseReset(?string $reset): ?DateTimeImmutable {
+        if ($reset === null || !ctype_digit($reset)) {
+            return null;
+        }
+
+        $value = (int) $reset;
+        // A large value is a Unix timestamp (X-RateLimit-Reset); a small value
+        // is delta-seconds from now (IETF RateLimit-Reset).
+        $timestamp = $value > 1_000_000_000 ? $value : time() + $value;
+
+        return (new DateTimeImmutable)->setTimestamp($timestamp);
+    }
+}

--- a/src/API/Transport/Psr18Transport.php
+++ b/src/API/Transport/Psr18Transport.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : Psr18Transport.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Transport;
+
+use InvalidArgumentException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\{RequestFactoryInterface, ResponseInterface, StreamFactoryInterface};
+
+/**
+ * Adapts the toolkit's Guzzle-style option array onto a PSR-18 client and
+ * PSR-17 factories, so any PSR-18 transport can back the API client (swappable
+ * transports, framework HTTP clients, easier mocking).
+ *
+ * Supported options: headers, query, json, form_params and a raw string body.
+ * PSR-18 has no notion of per-request timeout/proxy/TLS-verify or multipart, so
+ * those Guzzle options are ignored here — keep using an injected Guzzle client
+ * when you need them.
+ */
+class Psr18Transport {
+    private ClientInterface $client;
+    private RequestFactoryInterface $requestFactory;
+    private StreamFactoryInterface $streamFactory;
+    private string $baseUri;
+
+    public function __construct(
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        string $baseUri = ''
+    ) {
+        $this->client = $client;
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
+        $this->baseUri = rtrim($baseUri, '/');
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $uri, array $options = []): ResponseInterface {
+        $request = $this->requestFactory->createRequest($method, $this->resolveUri($uri, $options));
+
+        foreach (($options['headers'] ?? []) as $name => $value) {
+            $request = $request->withHeader((string) $name, is_array($value) ? $value : (string) $value);
+        }
+
+        $request = $this->applyBody($request, $options);
+
+        return $this->client->sendRequest($request);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function resolveUri(string $uri, array $options): string {
+        $absolute = preg_match('~^https?://~i', $uri) === 1 ? $uri : $this->baseUri . '/' . ltrim($uri, '/');
+
+        $query = $options['query'] ?? null;
+        if (is_array($query) && $query !== []) {
+            $absolute .= (str_contains($absolute, '?') ? '&' : '?') . http_build_query($query);
+        } elseif (is_string($query) && $query !== '') {
+            $absolute .= (str_contains($absolute, '?') ? '&' : '?') . $query;
+        }
+
+        return $absolute;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @param \Psr\Http\Message\RequestInterface $request
+     */
+    private function applyBody($request, array $options) {
+        if (array_key_exists('json', $options)) {
+            $body = json_encode($options['json']);
+            if ($body === false) {
+                throw new InvalidArgumentException('Could not JSON-encode the request payload');
+            }
+            if (!$request->hasHeader('Content-Type')) {
+                $request = $request->withHeader('Content-Type', 'application/json');
+            }
+
+            return $request->withBody($this->streamFactory->createStream($body));
+        }
+
+        if (isset($options['form_params']) && is_array($options['form_params'])) {
+            if (!$request->hasHeader('Content-Type')) {
+                $request = $request->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+            }
+
+            return $request->withBody($this->streamFactory->createStream(http_build_query($options['form_params'])));
+        }
+
+        if (isset($options['body']) && is_string($options['body'])) {
+            return $request->withBody($this->streamFactory->createStream($options['body']));
+        }
+
+        return $request;
+    }
+}

--- a/src/API/Webhook/WebhookVerifier.php
+++ b/src/API/Webhook/WebhookVerifier.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : WebhookVerifier.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Webhook;
+
+use InvalidArgumentException;
+
+/**
+ * Verifies inbound webhook signatures (HMAC) in constant time.
+ *
+ * Two common shapes are supported:
+ *  - a bare HMAC of the raw request body (verify()), accepting hex or base64
+ *    signatures, optionally prefixed with the algorithm (e.g. "sha256=…");
+ *  - a Stripe-style "t=<timestamp>,v1=<sig>" header where the signature is the
+ *    HMAC of "<timestamp>.<body>" and a timestamp tolerance guards against
+ *    replay (verifyTimestamped()).
+ *
+ * The comparison always uses hash_equals() so it does not leak via timing.
+ */
+class WebhookVerifier {
+    private string $algorithm;
+
+    public function __construct(string $algorithm = 'sha256') {
+        if (!in_array($algorithm, hash_hmac_algos(), true)) {
+            throw new InvalidArgumentException("Unsupported HMAC algorithm: {$algorithm}");
+        }
+        $this->algorithm = $algorithm;
+    }
+
+    /**
+     * Verify a signature computed as HMAC(secret, rawBody).
+     *
+     * Accepts the signature as lowercase hex or base64, with or without an
+     * "algo=" prefix (as some providers send, e.g. "sha256=abcdef…").
+     */
+    public function verify(string $rawBody, string $signature, #[\SensitiveParameter] string $secret): bool {
+        if ($signature === '' || $secret === '') {
+            return false;
+        }
+
+        $signature = self::stripAlgorithmPrefix($signature);
+
+        $expectedHex = hash_hmac($this->algorithm, $rawBody, $secret);
+        if (hash_equals($expectedHex, strtolower($signature))) {
+            return true;
+        }
+
+        $expectedBase64 = base64_encode((string) hash_hmac($this->algorithm, $rawBody, $secret, true));
+
+        return hash_equals($expectedBase64, $signature);
+    }
+
+    /**
+     * Verify a Stripe-style timestamped signature header
+     * ("t=<unix-ts>,v1=<hex-sig>[,v1=<hex-sig>…]").
+     *
+     * The signed payload is "<timestamp>.<rawBody>". Signatures older/newer
+     * than $tolerance seconds are rejected to prevent replay ($tolerance <= 0
+     * disables the check).
+     *
+     * @param int|null $now Reference time (defaults to time(); injectable for tests)
+     */
+    public function verifyTimestamped(string $rawBody, string $signatureHeader, #[\SensitiveParameter] string $secret, int $tolerance = 300, ?int $now = null): bool {
+        if ($signatureHeader === '' || $secret === '') {
+            return false;
+        }
+
+        $parsed = self::parseSignatureHeader($signatureHeader);
+        if ($parsed['t'] === [] || $parsed['signatures'] === []) {
+            return false;
+        }
+
+        $timestamp = $parsed['t'][0];
+        if (!ctype_digit($timestamp)) {
+            return false;
+        }
+
+        $now ??= time();
+        if ($tolerance > 0 && abs($now - (int) $timestamp) > $tolerance) {
+            return false;
+        }
+
+        $expected = hash_hmac($this->algorithm, $timestamp . '.' . $rawBody, $secret);
+
+        $valid = false;
+        // Compare against every provided signature without early-out so the
+        // work (and timing) does not depend on which one matches.
+        foreach ($parsed['signatures'] as $candidate) {
+            if (hash_equals($expected, strtolower($candidate))) {
+                $valid = true;
+            }
+        }
+
+        return $valid;
+    }
+
+    private static function stripAlgorithmPrefix(string $signature): string {
+        $pos = strpos($signature, '=');
+        if ($pos !== false && preg_match('/^[a-z0-9+\-]+$/i', substr($signature, 0, $pos)) === 1
+            && strlen($signature) - $pos > 8) {
+            // Only strip a short leading "algo=" token, never a base64 '=' pad.
+            $prefix = substr($signature, 0, $pos);
+            if (strlen($prefix) <= 12) {
+                return substr($signature, $pos + 1);
+            }
+        }
+
+        return $signature;
+    }
+
+    /**
+     * @return array{t: array<int, string>, signatures: array<int, string>}
+     */
+    private static function parseSignatureHeader(string $header): array {
+        $result = ['t' => [], 'signatures' => []];
+
+        foreach (explode(',', $header) as $part) {
+            $pair = explode('=', trim($part), 2);
+            if (count($pair) !== 2) {
+                continue;
+            }
+            [$key, $value] = $pair;
+            $key = trim($key);
+            if ($key === 't') {
+                $result['t'][] = trim($value);
+            } elseif ($key === 'v1') {
+                $result['signatures'][] = trim($value);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Contracts/Abstracts/API/ClientAbstract.php
+++ b/src/Contracts/Abstracts/API/ClientAbstract.php
@@ -79,6 +79,9 @@ abstract class ClientAbstract implements ApiClientInterface {
     protected bool $followRedirects = true;
     protected int $maxRedirects = 5;
 
+    protected bool $autoIdempotencyKey = false;
+    protected string $idempotencyHeader = 'Idempotency-Key';
+
     protected float $timeout = 30.0;
     protected float $connectTimeout = 10.0;
 
@@ -420,6 +423,32 @@ abstract class ClientAbstract implements ApiClientInterface {
         unset($this->defaultQueryParams[$name]);
     }
 
+    /**
+     * Automatically attach a generated idempotency key to mutating requests
+     * (POST/PUT/PATCH/DELETE) that do not already carry one. The key is
+     * generated once per logical call and reused across retries, so a request
+     * retried after a connection error / 5xx cannot create the resource twice.
+     */
+    public function setAutoIdempotencyKey(bool $enabled): void {
+        $this->autoIdempotencyKey = $enabled;
+    }
+
+    public function isAutoIdempotencyKeyEnabled(): bool {
+        return $this->autoIdempotencyKey;
+    }
+
+    /** Set the header name used to carry the idempotency key (default Idempotency-Key). */
+    public function setIdempotencyHeader(string $header): void {
+        if ($header === '') {
+            self::logErrorAndThrow(InvalidArgumentException::class, 'Idempotency header name must not be empty');
+        }
+        $this->idempotencyHeader = $header;
+    }
+
+    public function getIdempotencyHeader(): string {
+        return $this->idempotencyHeader;
+    }
+
     public function get(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('GET', $uri, $options);
     }
@@ -687,6 +716,10 @@ abstract class ClientAbstract implements ApiClientInterface {
     }
 
     protected function requestWithRetry(string $method, string $uri, array $options = []): ResponseInterface {
+        // Resolve the idempotency key once, before the retry loop, so every
+        // attempt sends the same key.
+        $options = $this->applyIdempotencyKey($method, $options);
+
         $attempt = 0;
         $authRefreshTried = false;
 
@@ -742,6 +775,35 @@ abstract class ClientAbstract implements ApiClientInterface {
             RuntimeException::class,
             "Max retries reached for {$method} request to {$uri}"
         );
+    }
+
+    /**
+     * Resolve the idempotency key for a request. An explicit
+     * $options['idempotency_key'] always wins; otherwise a key is generated
+     * for mutating verbs when auto mode is on and none is already set.
+     *
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>
+     */
+    protected function applyIdempotencyKey(string $method, array $options): array {
+        $explicit = $options['idempotency_key'] ?? null;
+        unset($options['idempotency_key']);
+
+        $alreadySet = false;
+        foreach (array_keys($options['headers'] ?? []) as $name) {
+            if (strcasecmp((string) $name, $this->idempotencyHeader) === 0) {
+                $alreadySet = true;
+                break;
+            }
+        }
+
+        if (is_string($explicit) && $explicit !== '') {
+            $options['headers'][$this->idempotencyHeader] = $explicit;
+        } elseif (!$alreadySet && $this->autoIdempotencyKey && in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            $options['headers'][$this->idempotencyHeader] = bin2hex(random_bytes(16));
+        }
+
+        return $options;
     }
 
     protected function calculateRetryDelay(int $attempt): int {

--- a/src/Contracts/Abstracts/API/ClientAbstract.php
+++ b/src/Contracts/Abstracts/API/ClientAbstract.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace APIToolkit\Contracts\Abstracts\API;
 
+use APIToolkit\API\RateLimit;
 use APIToolkit\Contracts\Interfaces\API\{ApiClientInterface, AuthenticationInterface, RefreshableAuthenticationInterface, RequestAwareAuthenticationInterface};
 use APIToolkit\Exceptions\{ApiException, BadGatewayException, BadRequestException, ConflictException, ForbiddenException, GatewayTimeoutException, InternalServerErrorException, NotAcceptableException, NotAllowedException, NotFoundException, PaymentRequiredException, RequestTimeoutException, ServiceUnavailableException, TooManyRequestsException, UnauthorizedException, UnprocessableEntityException, UnsupportedMediaTypeException};
 use ERRORToolkit\Traits\ErrorLog;
@@ -82,6 +83,13 @@ abstract class ClientAbstract implements ApiClientInterface {
     protected bool $autoIdempotencyKey = false;
     protected string $idempotencyHeader = 'Idempotency-Key';
 
+    /** @var array<int, callable> */
+    protected array $requestMiddleware = [];
+    /** @var array<int, callable> */
+    protected array $responseMiddleware = [];
+
+    protected ?RateLimit $lastRateLimit = null;
+
     protected float $timeout = 30.0;
     protected float $connectTimeout = 10.0;
 
@@ -97,6 +105,8 @@ abstract class ClientAbstract implements ApiClientInterface {
     protected HttpClient $client;
 
     protected bool $httpClientInjected = false;
+
+    protected ?\APIToolkit\API\Transport\Psr18Transport $psr18Transport = null;
 
     /**
      * Create a new API client
@@ -449,6 +459,65 @@ abstract class ClientAbstract implements ApiClientInterface {
         return $this->idempotencyHeader;
     }
 
+    /**
+     * Register a request interceptor. It receives ($method, $uri, $options)
+     * before the request is sent and may return a modified options array, or a
+     * ResponseInterface to short-circuit the call (e.g. a cache hit). Runs
+     * inside the toolkit so throttling, retry and log redaction still apply.
+     */
+    public function onRequest(callable $hook): void {
+        $this->requestMiddleware[] = $hook;
+    }
+
+    /**
+     * Register a response interceptor. It receives ($response, $method, $uri)
+     * after the response is received and may return a replacement response
+     * (e.g. a cache middleware turning a 304 into the cached 200).
+     */
+    public function onResponse(callable $hook): void {
+        $this->responseMiddleware[] = $hook;
+    }
+
+    /**
+     * The rate-limit budget advertised by the most recent response (parsed from
+     * the X-RateLimit or IETF RateLimit headers), or null when none was seen.
+     */
+    public function getLastRateLimit(): ?RateLimit {
+        return $this->lastRateLimit;
+    }
+
+    /**
+     * Start a fluent, discoverable request builder that lowers to the same
+     * options as the get()/post()/… methods.
+     */
+    public function pending(): \APIToolkit\API\PendingRequest {
+        return new \APIToolkit\API\PendingRequest($this);
+    }
+
+    /**
+     * Route requests through a PSR-18 client (with PSR-17 factories) instead of
+     * the internal Guzzle client. Pass null to revert to Guzzle. Supported
+     * options on this path: headers/query/json/form_params/body — per-request
+     * timeout/proxy/TLS-verify/multipart are Guzzle-only and ignored.
+     */
+    public function setPsr18Transport(
+        ?\Psr\Http\Client\ClientInterface $client,
+        ?\Psr\Http\Message\RequestFactoryInterface $requestFactory = null,
+        ?\Psr\Http\Message\StreamFactoryInterface $streamFactory = null
+    ): void {
+        if ($client === null) {
+            $this->psr18Transport = null;
+
+            return;
+        }
+
+        if ($requestFactory === null || $streamFactory === null) {
+            self::logErrorAndThrow(InvalidArgumentException::class, 'A PSR-18 transport requires PSR-17 request and stream factories');
+        }
+
+        $this->psr18Transport = new \APIToolkit\API\Transport\Psr18Transport($client, $requestFactory, $streamFactory, $this->baseUrl);
+    }
+
     public function get(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('GET', $uri, $options);
     }
@@ -551,8 +620,39 @@ abstract class ClientAbstract implements ApiClientInterface {
             $options['query'] = $query;
         }
 
+        // Request middleware may mutate the options or short-circuit the call
+        // by returning a response (e.g. a cache hit).
+        $shortCircuit = null;
+        foreach ($this->requestMiddleware as $hook) {
+            $result = $hook($method, $uri, $options);
+            if ($result instanceof ResponseInterface) {
+                $shortCircuit = $result;
+                break;
+            }
+            if (is_array($result)) {
+                $options = $result;
+            }
+        }
+
         $this->lastRequestTime = microtime(true);
-        $response = $this->client->request($method, $uri, $options);
+        if ($shortCircuit !== null) {
+            $response = $shortCircuit;
+        } elseif ($this->psr18Transport !== null) {
+            $response = $this->psr18Transport->request($method, $uri, $options);
+        } else {
+            $response = $this->client->request($method, $uri, $options);
+        }
+
+        $this->lastRateLimit = RateLimit::fromResponse($response) ?? $this->lastRateLimit;
+
+        // Response middleware may replace the response (e.g. turn a conditional
+        // 304 into the cached 200).
+        foreach ($this->responseMiddleware as $hook) {
+            $result = $hook($response, $method, $uri);
+            if ($result instanceof ResponseInterface) {
+                $response = $result;
+            }
+        }
 
         if ($this->sleepAfterRequest) {
             // Sleep for MIN_INTERVAL seconds after each request to ease up on

--- a/src/Contracts/Abstracts/API/ClientAbstract.php
+++ b/src/Contracts/Abstracts/API/ClientAbstract.php
@@ -48,6 +48,8 @@ abstract class ClientAbstract implements ApiClientInterface {
         'auth_token',
         'client_assertion',
         'client_secret',
+        'code',
+        'code_verifier',
         'password',
         'private_key',
         'refresh_token',
@@ -73,6 +75,9 @@ abstract class ClientAbstract implements ApiClientInterface {
     protected array $defaultHeaders = [];
 
     protected bool $verifySSL = true;
+
+    protected bool $followRedirects = true;
+    protected int $maxRedirects = 5;
 
     protected float $timeout = 30.0;
     protected float $connectTimeout = 10.0;
@@ -107,8 +112,29 @@ abstract class ClientAbstract implements ApiClientInterface {
             $this->client = $httpClient;
             $this->httpClientInjected = true;
         } else {
-            $this->client = new HttpClient(['base_uri' => $this->baseUrl]);
+            $this->client = new HttpClient($this->buildClientConfig());
         }
+    }
+
+    /**
+     * Build the Guzzle configuration for a client the toolkit creates itself.
+     *
+     * Redirect following is bounded and kept strict (the request method is
+     * preserved on 301/302, the Referer is not forwarded). Guzzle strips the
+     * Authorization and Cookie headers on a cross-host redirect; custom auth
+     * header names (e.g. an API-key header) are NOT stripped by Guzzle — for
+     * APIs where that matters, disable redirect following with
+     * setFollowRedirects(false).
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildClientConfig(): array {
+        return [
+            'base_uri' => $this->baseUrl,
+            'allow_redirects' => $this->followRedirects
+                ? ['max' => $this->maxRedirects, 'strict' => true, 'referer' => false]
+                : false,
+        ];
     }
 
     /**
@@ -136,8 +162,43 @@ abstract class ClientAbstract implements ApiClientInterface {
             return;
         }
 
-        $this->client = new HttpClient(['base_uri' => $this->baseUrl]);
+        $this->client = new HttpClient($this->buildClientConfig());
         $this->logDebug("Base URL changed to: {$this->baseUrl}");
+    }
+
+    /**
+     * Enable/disable following of HTTP redirects and cap their number.
+     *
+     * Disabling is recommended for APIs where a server-issued redirect must
+     * not carry a custom auth header (API key) to another host — Guzzle only
+     * strips Authorization/Cookie automatically. Only affects a client the
+     * toolkit created itself; an injected HTTP client keeps its own config.
+     *
+     * @param bool $follow Whether to follow redirects
+     * @param int  $maxRedirects Upper bound on redirects to follow (>= 1)
+     */
+    public function setFollowRedirects(bool $follow, int $maxRedirects = 5): void {
+        if ($maxRedirects < 1) {
+            self::logErrorAndThrow(
+                InvalidArgumentException::class,
+                'Max redirects must be at least 1'
+            );
+        }
+
+        $this->followRedirects = $follow;
+        $this->maxRedirects = $maxRedirects;
+
+        if ($this->httpClientInjected) {
+            $this->logWarning('Redirect policy changed, but an injected HTTP client is in use — its redirect config is unaffected.');
+
+            return;
+        }
+
+        $this->client = new HttpClient($this->buildClientConfig());
+    }
+
+    public function isFollowingRedirects(): bool {
+        return $this->followRedirects;
     }
 
     /**
@@ -397,21 +458,23 @@ abstract class ClientAbstract implements ApiClientInterface {
         }
 
         // Apply authentication headers if set (these override default headers)
+        $authHeaderNames = [];
         if ($this->authentication !== null) {
             if ($this->authentication->isValid()) {
                 $authHeaders = $this->authentication instanceof RequestAwareAuthenticationInterface
                     ? $this->authentication->getAuthHeadersFor($method, $uri, $this->extractRequestBody($options))
                     : $this->authentication->getAuthHeaders();
+                $authHeaderNames = array_keys($authHeaders);
                 $options['headers'] = array_merge(
                     $options['headers'] ?? [],
                     $authHeaders
                 );
             } else {
-                $this->logWarning("Authentication ({$this->authentication->getType()}) is set but not valid — sending {$method} request to {$uri} without auth headers.");
+                $this->logWarning("Authentication ({$this->authentication->getType()}) is set but not valid — sending {$method} request to " . self::sanitizeUriForLog($uri) . " without auth headers.");
             }
         }
 
-        $this->logDebug("Sending {$method} request to {$uri}" . ($sleepTime > 0 ? " (waited {$sleepTime} microseconds)" : ""), $this->sanitizeOptionsForLog($options));
+        $this->logDebug("Sending {$method} request to " . self::sanitizeUriForLog($uri) . ($sleepTime > 0 ? " (waited {$sleepTime} microseconds)" : ""), $this->sanitizeOptionsForLog($options, $authHeaderNames));
 
         // Client-wide defaults; an explicit per-request option wins so a
         // single long-running call can raise its timeout without touching
@@ -507,10 +570,18 @@ abstract class ClientAbstract implements ApiClientInterface {
      * @param array<string, mixed> $options
      * @return array<string, mixed>
      */
-    protected function sanitizeOptionsForLog(array $options): array {
+    protected function sanitizeOptionsForLog(array $options, array $extraSensitiveHeaders = []): array {
+        // Auth implementations may use arbitrary (non-standard) header names;
+        // those are passed in here so a custom key header is redacted even when
+        // its name is not on the static SENSITIVE_HEADERS allowlist.
+        $sensitiveHeaders = static::SENSITIVE_HEADERS;
+        foreach ($extraSensitiveHeaders as $name) {
+            $sensitiveHeaders[] = strtolower((string) $name);
+        }
+
         if (isset($options['headers']) && is_array($options['headers'])) {
             foreach (array_keys($options['headers']) as $name) {
-                if (in_array(strtolower((string) $name), static::SENSITIVE_HEADERS, true)) {
+                if (in_array(strtolower((string) $name), $sensitiveHeaders, true)) {
                     $options['headers'][$name] = self::REDACTED;
                 }
             }
@@ -518,6 +589,23 @@ abstract class ClientAbstract implements ApiClientInterface {
 
         if (array_key_exists('auth', $options)) {
             $options['auth'] = self::REDACTED;
+        }
+
+        // A raw string body (also the payload signed by request-aware auth) may
+        // carry credentials and is outside the query/form_params/json sections;
+        // replace it with a length placeholder rather than logging it verbatim.
+        if (isset($options['body']) && is_string($options['body'])) {
+            $options['body'] = '[raw body, ' . strlen($options['body']) . ' bytes]';
+        }
+
+        // Redact secret multipart fields by their declared name.
+        if (isset($options['multipart']) && is_array($options['multipart'])) {
+            foreach ($options['multipart'] as $index => $part) {
+                if (is_array($part) && isset($part['name']) && is_string($part['name'])
+                    && in_array(strtolower($part['name']), static::SENSITIVE_PARAMS, true)) {
+                    $options['multipart'][$index]['contents'] = self::REDACTED;
+                }
+            }
         }
 
         if (isset($options['query']) && is_string($options['query'])) {
@@ -532,6 +620,25 @@ abstract class ClientAbstract implements ApiClientInterface {
         }
 
         return $options;
+    }
+
+    /**
+     * Redact secrets embedded in a request URI before it is written to a log
+     * message: strips userinfo (user:pass@) and redacts known-sensitive query
+     * parameters (the same names as SENSITIVE_PARAMS).
+     */
+    protected static function sanitizeUriForLog(string $uri): string {
+        $uri = self::stripUrlCredentials($uri);
+
+        $parts = explode('?', $uri, 2);
+        if (!isset($parts[1]) || $parts[1] === '') {
+            return $uri;
+        }
+
+        parse_str($parts[1], $query);
+        $query = self::redactSensitiveParams($query);
+
+        return $parts[0] . '?' . http_build_query($query);
     }
 
     /**

--- a/src/Contracts/Abstracts/API/ClientAbstract.php
+++ b/src/Contracts/Abstracts/API/ClientAbstract.php
@@ -719,7 +719,7 @@ abstract class ClientAbstract implements ApiClientInterface {
                 ]);
 
                 sleep($delay);
-            } catch (TooManyRequestsException|ServiceUnavailableException|GatewayTimeoutException $e) {
+            } catch (TooManyRequestsException|BadGatewayException|ServiceUnavailableException|GatewayTimeoutException $e) {
                 $attempt++;
                 if ($attempt >= $this->maxRetries) {
                     self::logException($e);

--- a/src/Contracts/Abstracts/API/ClientAbstract.php
+++ b/src/Contracts/Abstracts/API/ClientAbstract.php
@@ -345,7 +345,7 @@ abstract class ClientAbstract implements ApiClientInterface {
      */
     public function setTimeout(float $timeout): void {
         if ($timeout < 0) {
-            throw new InvalidArgumentException('Timeout must be >= 0');
+            self::logErrorAndThrow(InvalidArgumentException::class, 'Timeout must be >= 0');
         }
         $this->timeout = $timeout;
     }
@@ -361,7 +361,7 @@ abstract class ClientAbstract implements ApiClientInterface {
      */
     public function setConnectTimeout(float $timeout): void {
         if ($timeout < 0) {
-            throw new InvalidArgumentException('Connect timeout must be >= 0');
+            self::logErrorAndThrow(InvalidArgumentException::class, 'Connect timeout must be >= 0');
         }
         $this->connectTimeout = $timeout;
     }
@@ -555,7 +555,8 @@ abstract class ClientAbstract implements ApiClientInterface {
         $response = $this->client->request($method, $uri, $options);
 
         if ($this->sleepAfterRequest) {
-            // Sleep for 0.5 seconds after each request to avoid rate limiting
+            // Sleep for MIN_INTERVAL seconds after each request to ease up on
+            // rate limits (independent of the pre-request requestInterval throttle).
             usleep((int) (self::MIN_INTERVAL * 1e6));
         }
 
@@ -736,31 +737,21 @@ abstract class ClientAbstract implements ApiClientInterface {
                 }
 
                 throw $e;
-            } catch (ConnectException $e) {
+            } catch (ConnectException|TooManyRequestsException|BadGatewayException|ServiceUnavailableException|GatewayTimeoutException $e) {
+                // Retryable transport/5xx errors share one path. A server
+                // response (for Retry-After) is only available on the toolkit's
+                // typed exceptions, not on Guzzle's ConnectException.
                 $attempt++;
                 if ($attempt >= $this->maxRetries) {
                     self::logException($e);
                     throw $e;
                 }
 
-                $delay = $this->resolveRetryDelay($attempt, null);
-                $this->logWarning("Retrying request due to connection error: {message} (attempt {attempt} of {maxRetries}, waiting {delay}s)", [
-                    'message' => $e->getMessage(),
-                    'attempt' => $attempt,
-                    'maxRetries' => $this->maxRetries,
-                    'delay' => $delay,
-                ]);
-
-                sleep($delay);
-            } catch (TooManyRequestsException|BadGatewayException|ServiceUnavailableException|GatewayTimeoutException $e) {
-                $attempt++;
-                if ($attempt >= $this->maxRetries) {
-                    self::logException($e);
-                    throw $e;
-                }
-
-                $delay = $this->resolveRetryDelay($attempt, $e->getResponse());
-                $this->logWarning("Retrying request due to error: {message} (attempt {attempt} of {maxRetries}, waiting {delay}s)", [
+                $response = $e instanceof ApiException ? $e->getResponse() : null;
+                $delay = $this->resolveRetryDelay($attempt, $response);
+                $this->logWarning("Retrying {method} {uri} after retryable error: {message} (attempt {attempt} of {maxRetries}, waiting {delay}s)", [
+                    'method' => $method,
+                    'uri' => self::sanitizeUriForLog($uri),
                     'message' => $e->getMessage(),
                     'attempt' => $attempt,
                     'maxRetries' => $this->maxRetries,

--- a/src/Contracts/Abstracts/API/EndpointAbstract.php
+++ b/src/Contracts/Abstracts/API/EndpointAbstract.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace APIToolkit\Contracts\Abstracts\API;
 
 use APIToolkit\Contracts\Interfaces\API\{ApiClientInterface, EndpointInterface};
+use APIToolkit\Contracts\Interfaces\NamedEntityInterface;
 use APIToolkit\Exceptions\ApiException;
 use ERRORToolkit\Traits\ErrorLog;
 use InvalidArgumentException;
@@ -78,6 +79,100 @@ abstract class EndpointAbstract implements EndpointInterface {
             $urlPath = $this->getEndpointUrl();
         }
         $response = $this->client->delete($urlPath, $options);
+
+        return $this->handleResponse($response, $statusCode);
+    }
+
+    /**
+     * GET the endpoint and decode the JSON body into an array (for ad-hoc
+     * mapping or paginators).
+     *
+     * @param array<string, mixed> $queryParams
+     * @param array<string, mixed> $options
+     * @return array<int|string, mixed>
+     */
+    protected function getArray(array $queryParams = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): array {
+        $decoded = json_decode($this->getContents($queryParams, $options, $urlPath, $statusCode), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * GET the endpoint and hydrate the JSON response into an entity/collection
+     * via its static fromJson(), removing per-SDK json_decode + mapping.
+     *
+     * @template T of NamedEntityInterface
+     * @param class-string<T> $entityClass
+     * @param array<string, mixed> $queryParams
+     * @param array<string, mixed> $options
+     * @return T
+     */
+    protected function getEntity(string $entityClass, array $queryParams = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): NamedEntityInterface {
+        return $entityClass::fromJson($this->getContents($queryParams, $options, $urlPath, $statusCode));
+    }
+
+    /**
+     * POST $data and hydrate the response into an entity/collection.
+     *
+     * @template T of NamedEntityInterface
+     * @param class-string<T> $entityClass
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
+     * @return T
+     */
+    protected function postEntity(string $entityClass, array $data = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 201): NamedEntityInterface {
+        return $entityClass::fromJson($this->postContents($data, $options, $urlPath, $statusCode));
+    }
+
+    /**
+     * PUT $data and hydrate the response into an entity/collection.
+     *
+     * @template T of NamedEntityInterface
+     * @param class-string<T> $entityClass
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
+     * @return T
+     */
+    protected function putEntity(string $entityClass, array $data = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): NamedEntityInterface {
+        return $entityClass::fromJson($this->putContents($data, $options, $urlPath, $statusCode));
+    }
+
+    /**
+     * PATCH $data and hydrate the response into an entity/collection.
+     *
+     * @template T of NamedEntityInterface
+     * @param class-string<T> $entityClass
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
+     * @return T
+     */
+    protected function patchEntity(string $entityClass, array $data = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): NamedEntityInterface {
+        return $entityClass::fromJson($this->patchContents($data, $options, $urlPath, $statusCode));
+    }
+
+    /**
+     * POST multipart/form-data (simple fields + file parts) — for document and
+     * attachment uploads that cannot use the JSON helpers.
+     *
+     * @param array<string, scalar> $fields Simple form fields (name => value)
+     * @param array<int, array<string, mixed>> $files Guzzle multipart parts (name/contents[/filename/headers])
+     * @param array<string, mixed> $options
+     */
+    protected function postMultipart(array $fields = [], array $files = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 201): string {
+        if (is_null($urlPath)) {
+            $urlPath = $this->getEndpointUrl();
+        }
+
+        $multipart = [];
+        foreach ($fields as $name => $value) {
+            $multipart[] = ['name' => (string) $name, 'contents' => (string) $value];
+        }
+        foreach ($files as $part) {
+            $multipart[] = $part;
+        }
+
+        $options['multipart'] = $multipart;
+        $response = $this->client->post($urlPath, $options);
 
         return $this->handleResponse($response, $statusCode);
     }

--- a/src/Contracts/Abstracts/API/EndpointAbstract.php
+++ b/src/Contracts/Abstracts/API/EndpointAbstract.php
@@ -115,14 +115,13 @@ abstract class EndpointAbstract implements EndpointInterface {
             );
         }
 
-        if (!empty($endpointPrefix) && !empty($endpointSuffix)) {
-            $result = "{$endpointPrefix}/{$endpoint}/{$endpointSuffix}";
-        } elseif (!empty($endpointPrefix)) {
-            $result = "{$endpointPrefix}/{$endpoint}";
-        } else {
-            $result = $endpoint;
-        }
+        // Nicht-leere Segmente in Reihenfolge zusammensetzen. Zuvor wurde ein
+        // gesetzter Suffix verworfen, wenn kein Prefix gesetzt war.
+        $segments = array_filter(
+            [$endpointPrefix, $endpoint, $endpointSuffix],
+            static fn (string $segment): bool => $segment !== ''
+        );
 
-        return $result;
+        return implode('/', $segments);
     }
 }

--- a/src/Contracts/Abstracts/AbstractUuid.php
+++ b/src/Contracts/Abstracts/AbstractUuid.php
@@ -20,6 +20,7 @@ use Stringable;
 
 abstract class AbstractUuid extends ID implements Stringable {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = $this->getEntityName();
         if (is_null($data)) {
             $data = $this->generateUuid()->toString();
         } elseif (is_string($data)) {
@@ -27,7 +28,6 @@ abstract class AbstractUuid extends ID implements Stringable {
         }
 
         parent::__construct($data, $logger);
-        $this->entityName = $this->getEntityName();
     }
 
     public function isValid(): bool {

--- a/src/Contracts/Abstracts/NamedEntity.php
+++ b/src/Contracts/Abstracts/NamedEntity.php
@@ -301,15 +301,15 @@ abstract class NamedEntity implements NamedEntityInterface {
             $otherValue = $other->{$key} ?? null;
 
             if ($thisValue instanceof NamedEntityInterface) {
-                if (!$thisValue->equals($otherValue)) {
+                if (!$otherValue instanceof NamedEntityInterface || !$thisValue->equals($otherValue)) {
                     return false;
                 }
             } elseif ($thisValue instanceof BackedEnum) {
-                if ($thisValue->value !== $otherValue->value) {
+                if (!$otherValue instanceof BackedEnum || $thisValue->value !== $otherValue->value) {
                     return false;
                 }
             } elseif ($thisValue instanceof DateTime || $thisValue instanceof DateTimeImmutable) {
-                if ($thisValue->getTimestamp() !== $otherValue->getTimestamp()) {
+                if (!($otherValue instanceof DateTime || $otherValue instanceof DateTimeImmutable) || $thisValue->getTimestamp() !== $otherValue->getTimestamp()) {
                     return false;
                 }
             } else {

--- a/src/Contracts/Abstracts/NamedValue.php
+++ b/src/Contracts/Abstracts/NamedValue.php
@@ -61,6 +61,16 @@ abstract class NamedValue implements NamedValueInterface {
         return $this->readOnly;
     }
 
+    /**
+     * Mark this value as read-only. Any later setData() then throws, which
+     * previously could never happen (the guard in setData() was unreachable
+     * because nothing set the flag).
+     */
+    public function markReadOnly(): static {
+        $this->readOnly = true;
+        return $this;
+    }
+
     public function isValid(): bool {
         return true;
     }

--- a/src/Entities/Bank/BIC.php
+++ b/src/Entities/Bank/BIC.php
@@ -18,11 +18,11 @@ use Psr\Log\LoggerInterface;
 
 class BIC extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'bic';
         if (is_string($data)) {
             $data = strtoupper(trim($data));
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'bic';
     }
 
     public function isValid(): bool {

--- a/src/Entities/Bank/IBAN.php
+++ b/src/Entities/Bank/IBAN.php
@@ -18,11 +18,11 @@ use Psr\Log\LoggerInterface;
 
 class IBAN extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'iban';
         if (is_string($data)) {
             $data = strtoupper(str_replace(' ', '', trim($data)));
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'iban';
     }
 
     public function isValid(): bool {

--- a/src/Entities/Common/Addresses.php
+++ b/src/Entities/Common/Addresses.php
@@ -13,16 +13,11 @@ declare(strict_types=1);
 namespace APIToolkit\Entities\Common;
 
 use APIToolkit\Contracts\Abstracts\NamedValues;
-use Psr\Log\LoggerInterface;
 
 /**
  * @extends NamedValues<Address>
  */
 class Addresses extends NamedValues {
-    public function __construct($data = null, ?LoggerInterface $logger = null) {
-        $this->entityName = "content";
-        $this->valueClassName = Address::class;
-
-        parent::__construct($data, $logger);
-    }
+    protected string $entityName = "content";
+    protected string $valueClassName = Address::class;
 }

--- a/src/Entities/Common/Persons.php
+++ b/src/Entities/Common/Persons.php
@@ -13,16 +13,11 @@ declare(strict_types=1);
 namespace APIToolkit\Entities\Common;
 
 use APIToolkit\Contracts\Abstracts\NamedValues;
-use Psr\Log\LoggerInterface;
 
 /**
  * @extends NamedValues<Person>
  */
 class Persons extends NamedValues {
-    public function __construct($data = null, ?LoggerInterface $logger = null) {
-        $this->entityName = "content";
-        $this->valueClassName = Person::class;
-
-        parent::__construct($data, $logger);
-    }
+    protected string $entityName = "content";
+    protected string $valueClassName = Person::class;
 }

--- a/src/Entities/Contact/EmailAddress.php
+++ b/src/Entities/Contact/EmailAddress.php
@@ -18,11 +18,11 @@ use Psr\Log\LoggerInterface;
 
 class EmailAddress extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'emailAddress';
         if (is_string($data)) {
             $data = EmailHelper::normalize($data);
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'emailAddress';
     }
 
     public function isValid(): bool {

--- a/src/Entities/Contact/EmailAddresses.php
+++ b/src/Entities/Contact/EmailAddresses.php
@@ -13,16 +13,11 @@ declare(strict_types=1);
 namespace APIToolkit\Entities\Contact;
 
 use APIToolkit\Contracts\Abstracts\NamedValues;
-use Psr\Log\LoggerInterface;
 
 /**
  * @extends NamedValues<EmailAddress>
  */
 class EmailAddresses extends NamedValues {
-    public function __construct($data = null, ?LoggerInterface $logger = null) {
-        $this->entityName = "content";
-        $this->valueClassName = EmailAddress::class;
-
-        parent::__construct($data, $logger);
-    }
+    protected string $entityName = "content";
+    protected string $valueClassName = EmailAddress::class;
 }

--- a/src/Entities/Contact/PhoneNumber.php
+++ b/src/Entities/Contact/PhoneNumber.php
@@ -18,8 +18,8 @@ use Psr\Log\LoggerInterface;
 
 class PhoneNumber extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
-        parent::__construct($data, $logger);
         $this->entityName = 'phoneNumber';
+        parent::__construct($data, $logger);
     }
 
     public function isValid(): bool {

--- a/src/Entities/Contact/PhoneNumbers.php
+++ b/src/Entities/Contact/PhoneNumbers.php
@@ -13,16 +13,11 @@ declare(strict_types=1);
 namespace APIToolkit\Entities\Contact;
 
 use APIToolkit\Contracts\Abstracts\NamedValues;
-use Psr\Log\LoggerInterface;
 
 /**
  * @extends NamedValues<PhoneNumber>
  */
 class PhoneNumbers extends NamedValues {
-    public function __construct($data = null, ?LoggerInterface $logger = null) {
-        $this->entityName = "content";
-        $this->valueClassName = PhoneNumber::class;
-
-        parent::__construct($data, $logger);
-    }
+    protected string $entityName = "content";
+    protected string $valueClassName = PhoneNumber::class;
 }

--- a/src/Entities/ID.php
+++ b/src/Entities/ID.php
@@ -17,11 +17,16 @@ use Psr\Log\LoggerInterface;
 
 class ID extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        // Nur setzen, wenn eine abgeleitete Klasse (z. B. UUID/GUID über
+        // AbstractUuid) den Namen nicht bereits vor diesem Konstruktor
+        // festgelegt hat.
+        if ($this->entityName === '') {
+            $this->entityName = 'id';
+        }
         if (is_null($data)) {
             $data = 0;
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'id';
     }
 
     public function isValid(): bool {

--- a/src/Entities/Information/Link.php
+++ b/src/Entities/Information/Link.php
@@ -18,11 +18,11 @@ use Psr\Log\LoggerInterface;
 
 class Link extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'link';
         if (is_string($data)) {
             $data = WebLinkHelper::normalize($data) ?? $data;
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'link';
     }
 
     public function isValid(): bool {

--- a/src/Entities/Information/Links.php
+++ b/src/Entities/Information/Links.php
@@ -13,16 +13,11 @@ declare(strict_types=1);
 namespace APIToolkit\Entities\Information;
 
 use APIToolkit\Contracts\Abstracts\NamedValues;
-use Psr\Log\LoggerInterface;
 
 /**
  * @extends NamedValues<Link>
  */
 class Links extends NamedValues {
-    public function __construct($data = null, ?LoggerInterface $logger = null) {
-        $this->entityName = "content";
-        $this->valueClassName = Link::class;
-
-        parent::__construct($data, $logger);
-    }
+    protected string $entityName = "content";
+    protected string $valueClassName = Link::class;
 }

--- a/src/Entities/ProgramVersion.php
+++ b/src/Entities/ProgramVersion.php
@@ -25,11 +25,11 @@ class ProgramVersion extends Version {
     private ?string $buildMetadata = null;
 
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'version';
         if (is_null($data)) {
             $data = 'v0.0.0';
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'version';
         $this->parseVersion();
     }
 

--- a/src/Entities/StringValue.php
+++ b/src/Entities/StringValue.php
@@ -21,7 +21,32 @@ class StringValue extends NamedValue {
     protected ?string $pattern = null;
 
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'stringValue';
         parent::__construct($data, $logger);
+    }
+
+    /**
+     * Set the minimum allowed length applied by isValid() (null disables it).
+     */
+    public function setMinLength(?int $minLength): self {
+        $this->minLength = $minLength;
+        return $this;
+    }
+
+    /**
+     * Set the maximum allowed length applied by isValid() (null disables it).
+     */
+    public function setMaxLength(?int $maxLength): self {
+        $this->maxLength = $maxLength;
+        return $this;
+    }
+
+    /**
+     * Set a PCRE pattern the value must match in isValid() (null disables it).
+     */
+    public function setPattern(?string $pattern): self {
+        $this->pattern = $pattern;
+        return $this;
     }
 
     public function isValid(): bool {

--- a/src/Entities/StringValues.php
+++ b/src/Entities/StringValues.php
@@ -13,18 +13,13 @@ declare(strict_types=1);
 namespace APIToolkit\Entities;
 
 use APIToolkit\Contracts\Abstracts\NamedValues;
-use Psr\Log\LoggerInterface;
 
 /**
  * @extends NamedValues<StringValue>
  */
 class StringValues extends NamedValues {
-    public function __construct($data = null, ?LoggerInterface $logger = null) {
-        $this->entityName = "content";
-        $this->valueClassName = StringValue::class;
-
-        parent::__construct($data, $logger);
-    }
+    protected string $entityName = "content";
+    protected string $valueClassName = StringValue::class;
 
     public function toArray(): array {
         $result = [];

--- a/src/Entities/Tax/VAT.php
+++ b/src/Entities/Tax/VAT.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
 
 class VAT extends NamedValue {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'vat';
         if (is_string($data)) {
             $data = VatNumberHelper::normalize($data);
         } elseif (is_null($data)) {

--- a/src/Entities/Version.php
+++ b/src/Entities/Version.php
@@ -18,11 +18,11 @@ use Stringable;
 
 class Version extends NamedValue implements Stringable {
     public function __construct(mixed $data = null, ?LoggerInterface $logger = null) {
+        $this->entityName = 'version';
         if (is_null($data)) {
             $data = 1;
         }
         parent::__construct($data, $logger);
-        $this->entityName = 'version';
     }
 
     public function isValid(): bool {

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -23,6 +23,23 @@ class ApiException extends Exception {
     /** Maximum number of response-body characters written to the log context. */
     public const MAX_LOGGED_CONTENT = 2048;
 
+    /**
+     * Response header names (lowercase) whose values are redacted before they
+     * are written to the log context. Mirrors the request-side redaction in
+     * ClientAbstract so a server's Set-Cookie / auth headers do not leak into
+     * the logs on a 4xx/5xx (works with any PSR-3 logger, not just the
+     * error-toolkit loggers that additionally redact defensively).
+     */
+    protected const SENSITIVE_RESPONSE_HEADERS = [
+        'set-cookie',
+        'authorization',
+        'proxy-authorization',
+        'www-authenticate',
+        'cookie',
+    ];
+
+    private const REDACTED = '[redacted]';
+
     protected ?ResponseInterface $response;
     protected ?string $responseContent = null;
 
@@ -43,7 +60,7 @@ class ApiException extends Exception {
         ];
 
         if ($response !== null) {
-            $context['response_headers'] = $response->getHeaders();
+            $context['response_headers'] = self::redactHeaders($response->getHeaders());
         }
 
         // 4xx responses are frequently expected control flow on the caller
@@ -60,6 +77,23 @@ class ApiException extends Exception {
 
     public function getContent(): ?string {
         return $this->responseContent;
+    }
+
+    /**
+     * Redact sensitive response header values before they reach the log
+     * context. Non-sensitive headers are kept verbatim.
+     *
+     * @param array<string, array<int, string>> $headers
+     * @return array<string, mixed>
+     */
+    protected static function redactHeaders(array $headers): array {
+        foreach (array_keys($headers) as $name) {
+            if (in_array(strtolower((string) $name), self::SENSITIVE_RESPONSE_HEADERS, true)) {
+                $headers[$name] = self::REDACTED;
+            }
+        }
+
+        return $headers;
     }
 
     protected function extractContent(): ?string {

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -80,6 +80,68 @@ class ApiException extends Exception {
     }
 
     /**
+     * Parse the response body as an RFC 7807 problem+json document, if it looks
+     * like one (contains at least one of type/title/detail/status).
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getProblemDetails(): ?array {
+        $decoded = $this->decodedBody();
+
+        foreach (['type', 'title', 'detail', 'status'] as $key) {
+            if (array_key_exists($key, $decoded)) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Best-effort machine-readable error code from common JSON error envelopes
+     * (problem+json / {error|code|error_code, …}).
+     */
+    public function getErrorCode(): ?string {
+        $decoded = $this->decodedBody();
+
+        foreach (['error_code', 'code', 'error'] as $key) {
+            if (isset($decoded[$key]) && (is_string($decoded[$key]) || is_int($decoded[$key]))) {
+                return (string) $decoded[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Best-effort human-readable error message from common JSON error envelopes.
+     */
+    public function getErrorMessage(): ?string {
+        $decoded = $this->decodedBody();
+
+        foreach (['detail', 'message', 'error_description'] as $key) {
+            if (isset($decoded[$key]) && is_string($decoded[$key])) {
+                return $decoded[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodedBody(): array {
+        if ($this->responseContent === null || $this->responseContent === '') {
+            return [];
+        }
+
+        $decoded = json_decode($this->responseContent, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
      * Redact sensitive response header values before they reach the log
      * context. Non-sensitive headers are kept verbatim.
      *

--- a/tests/ApiExceptionRedactionTest.php
+++ b/tests/ApiExceptionRedactionTest.php
@@ -59,6 +59,26 @@ class ApiExceptionRedactionTest extends Test {
         $this->assertStringNotContainsString('abc123', $serialized);
     }
 
+    public function test_problem_json_and_error_accessors(): void {
+        $response = new Response(422, ['Content-Type' => 'application/problem+json'], '{"type":"https://ex/errors/validation","title":"Invalid","detail":"amount must be positive","status":422}');
+
+        $exception = new ProblemLikeException('Unprocessable Entity', 422, $response, null, $this->spyLogger);
+
+        $problem = $exception->getProblemDetails();
+        $this->assertIsArray($problem);
+        $this->assertSame('Invalid', $problem['title']);
+        $this->assertSame('amount must be positive', $exception->getErrorMessage());
+    }
+
+    public function test_error_code_from_simple_envelope(): void {
+        $response = new Response(400, [], '{"error":"invalid_grant","error_description":"code expired"}');
+        $exception = new ProblemLikeException('Bad Request', 400, $response, null, $this->spyLogger);
+
+        $this->assertSame('invalid_grant', $exception->getErrorCode());
+        $this->assertSame('code expired', $exception->getErrorMessage());
+        $this->assertNull($exception->getProblemDetails()); // not a problem+json shape
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -75,3 +95,6 @@ class ApiExceptionRedactionTest extends Test {
 
 /** Concrete ApiException so the constructor's auto-logging path is exercised. */
 class ForbiddenLikeException extends ApiException {}
+
+/** Concrete ApiException for the problem+json / error-accessor tests. */
+class ProblemLikeException extends ApiException {}

--- a/tests/ApiExceptionRedactionTest.php
+++ b/tests/ApiExceptionRedactionTest.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : ApiExceptionRedactionTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\Exceptions\ApiException;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\{AbstractLogger, LoggerInterface};
+use Tests\Contracts\Test;
+
+class ApiExceptionRedactionTest extends Test {
+    /** @var AbstractLogger&object{records: array<int, array{level: mixed, message: string, context: array<string, mixed>}>} */
+    private AbstractLogger $spyLogger;
+
+    private ?LoggerInterface $previousLogger = null;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->previousLogger = ApiException::getLogger();
+        $this->spyLogger = new class extends AbstractLogger {
+            /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void {
+                $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+    }
+
+    protected function tearDown(): void {
+        ApiException::setLogger($this->previousLogger);
+        parent::tearDown();
+    }
+
+    public function test_response_set_cookie_and_auth_headers_are_redacted_in_log(): void {
+        $response = new Response(403, [
+            'Set-Cookie' => 'SESSIONID=abc123; HttpOnly',
+            'WWW-Authenticate' => 'Bearer realm="api"',
+            'Content-Type' => 'application/json',
+        ], '{"error":"forbidden"}');
+
+        new ForbiddenLikeException('Forbidden', 403, $response, null, $this->spyLogger);
+
+        $context = $this->exceptionContext();
+        $this->assertSame('[redacted]', $context['response_headers']['Set-Cookie']);
+        $this->assertSame('[redacted]', $context['response_headers']['WWW-Authenticate']);
+        $this->assertSame(['application/json'], $context['response_headers']['Content-Type']);
+
+        $serialized = (string) json_encode($this->spyLogger->records);
+        $this->assertStringNotContainsString('abc123', $serialized);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exceptionContext(): array {
+        foreach ($this->spyLogger->records as $record) {
+            if (array_key_exists('response_headers', $record['context'])) {
+                return $record['context'];
+            }
+        }
+
+        $this->fail('No exception log record with response_headers captured');
+    }
+}
+
+/** Concrete ApiException so the constructor's auto-logging path is exercised. */
+class ForbiddenLikeException extends ApiException {}

--- a/tests/Authentication/HmacAuthenticationTest.php
+++ b/tests/Authentication/HmacAuthenticationTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : HmacAuthenticationTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+namespace Tests\Authentication;
+
+use APIToolkit\API\Authentication\HmacAuthentication;
+use APIToolkit\Contracts\Interfaces\API\RequestAwareAuthenticationInterface;
+use InvalidArgumentException;
+use Tests\Contracts\Test;
+
+class HmacAuthenticationTest extends Test {
+    public function test_is_a_request_aware_authentication(): void {
+        $this->assertInstanceOf(RequestAwareAuthenticationInterface::class, new HmacAuthentication('key', 'secret'));
+    }
+
+    public function test_signs_request_with_key_id_and_timestamp(): void {
+        $auth = new HmacAuthentication('key-1', 'topsecret');
+
+        $headers = $auth->getAuthHeadersFor('POST', '/charges', '{"amount":100}');
+
+        $this->assertSame('key-1', $headers['X-Key-Id']);
+        $this->assertArrayHasKey('X-Timestamp', $headers);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $headers['X-Signature']);
+    }
+
+    public function test_signature_binds_method_uri_and_body(): void {
+        $auth = new HmacAuthentication('key-1', 'topsecret');
+
+        // Reconstruct the expected signature deterministically using the
+        // timestamp the auth emitted, then vary each component.
+        $base = $auth->getAuthHeadersFor('POST', '/a', 'body-1');
+        $ts = $base['X-Timestamp'];
+
+        $expected = hash_hmac('sha256', "POST\n/a\n{$ts}\n" . hash('sha256', 'body-1'), 'topsecret');
+        $this->assertSame($expected, $base['X-Signature']);
+
+        // A different body under the same timestamp yields a different sig.
+        $other = hash_hmac('sha256', "POST\n/a\n{$ts}\n" . hash('sha256', 'body-2'), 'topsecret');
+        $this->assertNotSame($base['X-Signature'], $other);
+    }
+
+    public function test_validity_and_debug_redaction(): void {
+        $this->assertTrue((new HmacAuthentication('k', 's'))->isValid());
+        $this->assertFalse((new HmacAuthentication('', 's'))->isValid());
+        $this->assertFalse((new HmacAuthentication('k', ''))->isValid());
+
+        $dump = (new HmacAuthentication('k', 'super'))->__debugInfo();
+        $this->assertSame('[redacted]', $dump['secret']);
+        $this->assertSame('HMAC', (new HmacAuthentication('k', 's'))->getType());
+    }
+
+    public function test_rejects_unknown_algorithm(): void {
+        $this->expectException(InvalidArgumentException::class);
+        new HmacAuthentication('k', 's', 'nope-algo');
+    }
+}

--- a/tests/Authentication/OAuth2AuthorizationCodeGrantTest.php
+++ b/tests/Authentication/OAuth2AuthorizationCodeGrantTest.php
@@ -40,6 +40,30 @@ class OAuth2AuthorizationCodeGrantTest extends Test {
         new OAuth2AuthorizationCodeGrant('', 'secret', 'https://a', 'https://t');
     }
 
+    public function test_public_pkce_client_exchanges_code_without_client_secret() {
+        $mock = new MockHandler([new Response(200, [], '{"access_token":"tok","token_type":"Bearer"}')]);
+        // Public client: empty secret is allowed and no client_secret is sent.
+        $grant = new OAuth2AuthorizationCodeGrant(
+            'public-client',
+            '',
+            'https://provider.example.com/oauth/authorize',
+            'https://provider.example.com/oauth/access_token',
+            'https://app.example.com/callback',
+            null,
+            new HttpClient(['handler' => HandlerStack::create($mock)])
+        );
+
+        $verifier = OAuth2AuthorizationCodeGrant::generatePkceVerifier();
+        $token = $grant->exchangeAuthorizationCode('auth-code', $verifier);
+
+        $this->assertSame('tok', $token->getAccessToken());
+
+        parse_str((string) $mock->getLastRequest()->getBody(), $body);
+        $this->assertSame('public-client', $body['client_id']);
+        $this->assertArrayNotHasKey('client_secret', $body);
+        $this->assertSame($verifier, $body['code_verifier']);
+    }
+
     public function test_authorization_url_contains_expected_parameters() {
         $grant = $this->makeGrant();
 

--- a/tests/Authentication/OAuth2DeviceCodeGrantTest.php
+++ b/tests/Authentication/OAuth2DeviceCodeGrantTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : OAuth2DeviceCodeGrantTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+namespace Tests\Authentication;
+
+use APIToolkit\API\Authentication\OAuth2\{OAuth2DeviceCodeGrant, OAuth2Token};
+use APIToolkit\Exceptions\BadRequestException;
+use GuzzleHttp\{Client as HttpClient, HandlerStack};
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Tests\Contracts\Test;
+
+class OAuth2DeviceCodeGrantTest extends Test {
+    private function makeGrant(MockHandler $mock): OAuth2DeviceCodeGrant {
+        // Subclass overrides wait() so polling does not actually sleep.
+        return new class('device-client', '', 'https://provider.example.com/device/code', 'https://provider.example.com/token', null, new HttpClient(['handler' => HandlerStack::create($mock)])) extends OAuth2DeviceCodeGrant {
+            protected function wait(int $seconds): void {}
+        };
+    }
+
+    public function test_request_device_code_normalizes_interval(): void {
+        $mock = new MockHandler([
+            new Response(200, [], '{"device_code":"dev-123","user_code":"WXYZ-1234","verification_uri":"https://ex/activate","expires_in":900}'),
+        ]);
+
+        $result = $this->makeGrant($mock)->requestDeviceCode(['read']);
+
+        $this->assertSame('dev-123', $result['device_code']);
+        $this->assertSame('WXYZ-1234', $result['user_code']);
+        $this->assertSame(5, $result['interval']); // default when omitted
+        $this->assertSame(900, $result['expires_in']);
+    }
+
+    public function test_poll_returns_token_after_authorization_pending(): void {
+        $mock = new MockHandler([
+            new Response(400, [], '{"error":"authorization_pending"}'),
+            new Response(400, [], '{"error":"slow_down"}'),
+            new Response(200, [], '{"access_token":"tok-abc","token_type":"Bearer","expires_in":3600}'),
+        ]);
+
+        $token = $this->makeGrant($mock)->pollForToken('dev-123', 1);
+
+        $this->assertInstanceOf(OAuth2Token::class, $token);
+        $this->assertSame('tok-abc', $token->getAccessToken());
+    }
+
+    public function test_poll_throws_on_access_denied(): void {
+        $mock = new MockHandler([
+            new Response(400, [], '{"error":"authorization_pending"}'),
+            new Response(400, [], '{"error":"access_denied"}'),
+        ]);
+
+        $this->expectException(BadRequestException::class);
+        $this->makeGrant($mock)->pollForToken('dev-123', 1);
+    }
+}

--- a/tests/ClientExtensionsTest.php
+++ b/tests/ClientExtensionsTest.php
@@ -1,0 +1,172 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : ClientExtensionsTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\API\Cache\Psr16ResponseCache;
+use APIToolkit\Contracts\Abstracts\API\ClientAbstract;
+use GuzzleHttp\{Client as HttpClient, HandlerStack};
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\{HttpFactory, Response};
+use Psr\SimpleCache\CacheInterface;
+use Tests\Contracts\Test;
+
+class ClientExtensionsTest extends Test {
+    private MockHandler $mockHandler;
+
+    private function makeClient(array $queue): ClientAbstract {
+        $this->mockHandler = new MockHandler($queue);
+        $httpClient = new HttpClient(['handler' => HandlerStack::create($this->mockHandler)]);
+        $client = new class('https://api.example.com', null, false, $httpClient) extends ClientAbstract {};
+        $client->setRequestInterval(0.0);
+
+        return $client;
+    }
+
+    private function arrayCache(): CacheInterface {
+        return new class implements CacheInterface {
+            /** @var array<string, mixed> */
+            public array $data = [];
+
+            public function get(string $key, mixed $default = null): mixed {
+                return $this->data[$key] ?? $default;
+            }
+
+            public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool {
+                $this->data[$key] = $value;
+
+                return true;
+            }
+
+            public function delete(string $key): bool {
+                unset($this->data[$key]);
+
+                return true;
+            }
+
+            public function clear(): bool {
+                $this->data = [];
+
+                return true;
+            }
+
+            public function getMultiple(iterable $keys, mixed $default = null): iterable {
+                return [];
+            }
+
+            public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool {
+                return true;
+            }
+
+            public function deleteMultiple(iterable $keys): bool {
+                return true;
+            }
+
+            public function has(string $key): bool {
+                return isset($this->data[$key]);
+            }
+        };
+    }
+
+    public function test_rate_limit_parsed_from_headers(): void {
+        $client = $this->makeClient([
+            new Response(200, ['X-RateLimit-Limit' => '100', 'X-RateLimit-Remaining' => '7', 'X-RateLimit-Reset' => (string) (time() + 30)], '{}'),
+        ]);
+
+        $this->assertNull($client->getLastRateLimit());
+        $client->get('/x');
+
+        $rl = $client->getLastRateLimit();
+        $this->assertNotNull($rl);
+        $this->assertSame(100, $rl->limit);
+        $this->assertSame(7, $rl->remaining);
+        $this->assertFalse($rl->isExhausted());
+        $this->assertGreaterThan(0, $rl->secondsUntilReset());
+    }
+
+    public function test_request_middleware_can_mutate_options(): void {
+        $client = $this->makeClient([new Response(200, [], '{}')]);
+        $client->onRequest(function (string $method, string $uri, array $options): array {
+            $options['headers']['X-Trace'] = 'abc-123';
+
+            return $options;
+        });
+
+        $client->get('/x');
+
+        $this->assertSame('abc-123', $this->mockHandler->getLastRequest()->getHeaderLine('X-Trace'));
+    }
+
+    public function test_request_middleware_can_short_circuit(): void {
+        $client = $this->makeClient([]); // no network response queued
+        $client->onRequest(fn (string $method, string $uri, array $options) => new Response(200, [], 'from-cache'));
+
+        $response = $client->get('/x');
+        $this->assertSame('from-cache', (string) $response->getBody());
+    }
+
+    public function test_pending_request_builder_lowers_to_options(): void {
+        $client = $this->makeClient([new Response(201, [], '{}')]);
+
+        $client->pending()
+            ->withHeader('Accept', 'application/json')
+            ->withJson(['amount' => 100])
+            ->withIdempotencyKey('key-9')
+            ->post('/charges');
+
+        $sent = $this->mockHandler->getLastRequest();
+        $this->assertSame('application/json', $sent->getHeaderLine('Accept'));
+        $this->assertSame('key-9', $sent->getHeaderLine('Idempotency-Key'));
+        $this->assertSame('{"amount":100}', (string) $sent->getBody());
+    }
+
+    public function test_response_cache_serves_fresh_entry_without_network(): void {
+        $client = $this->makeClient([new Response(200, ['Content-Type' => 'application/json'], '{"v":1}')]);
+        (new Psr16ResponseCache($this->arrayCache(), 300))->register($client);
+
+        $first = (string) $client->get('/data')->getBody();
+        // Only one response queued; a second GET must be served from cache.
+        $second = (string) $client->get('/data')->getBody();
+
+        $this->assertSame('{"v":1}', $first);
+        $this->assertSame('{"v":1}', $second);
+    }
+
+    public function test_response_cache_revalidates_with_304(): void {
+        $client = $this->makeClient([
+            new Response(200, ['ETag' => '"abc"', 'Content-Type' => 'application/json'], '{"v":1}'),
+            new Response(304, ['ETag' => '"abc"']),
+        ]);
+        // ttl 0 → never fresh, always revalidate via If-None-Match.
+        (new Psr16ResponseCache($this->arrayCache(), 0))->register($client);
+
+        $client->get('/data');
+        $second = $client->get('/data');
+
+        $this->assertSame('"abc"', $this->mockHandler->getLastRequest()->getHeaderLine('If-None-Match'));
+        $this->assertSame('{"v":1}', (string) $second->getBody()); // 304 served from cache
+    }
+
+    public function test_psr18_transport_sends_json_request(): void {
+        $client = $this->makeClient([new Response(200, [], '{"ok":true}')]);
+        $factory = new HttpFactory;
+        $client->setPsr18Transport(new HttpClient(['handler' => HandlerStack::create($this->mockHandler)]), $factory, $factory);
+
+        $response = $client->post('/charges', ['json' => ['a' => 1]]);
+
+        $this->assertSame('{"ok":true}', (string) $response->getBody());
+        $sent = $this->mockHandler->getLastRequest();
+        $this->assertSame('POST', $sent->getMethod());
+        $this->assertStringContainsString('application/json', $sent->getHeaderLine('Content-Type'));
+        $this->assertSame('{"a":1}', (string) $sent->getBody());
+    }
+}

--- a/tests/ClientIdempotencyTest.php
+++ b/tests/ClientIdempotencyTest.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : ClientIdempotencyTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\Contracts\Abstracts\API\ClientAbstract;
+use GuzzleHttp\{Client as HttpClient, HandlerStack};
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\{Request, Response};
+use Tests\Contracts\Test;
+
+class ClientIdempotencyTest extends Test {
+    private MockHandler $mockHandler;
+
+    private function makeClient(array $queue): ClientAbstract {
+        $this->mockHandler = new MockHandler($queue);
+        $httpClient = new HttpClient(['handler' => HandlerStack::create($this->mockHandler)]);
+
+        $client = new class('https://api.example.com', null, false, $httpClient) extends ClientAbstract {};
+        $client->setRequestInterval(0.0);
+        $client->setBaseRetryDelay(0);
+
+        return $client;
+    }
+
+    public function test_auto_key_added_to_post_when_enabled(): void {
+        $client = $this->makeClient([new Response(200, [], '{}')]);
+        $client->setAutoIdempotencyKey(true);
+
+        $client->post('/charges', ['json' => ['amount' => 100]]);
+
+        $sent = $this->mockHandler->getLastRequest();
+        $this->assertNotNull($sent);
+        $this->assertTrue($sent->hasHeader('Idempotency-Key'));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $sent->getHeaderLine('Idempotency-Key'));
+    }
+
+    public function test_no_key_on_get_or_when_disabled(): void {
+        $client = $this->makeClient([new Response(200, [], '{}'), new Response(200, [], '{}')]);
+
+        // GET with auto enabled → still no key (GET is not mutating)
+        $client->setAutoIdempotencyKey(true);
+        $client->get('/charges');
+        $this->assertFalse($this->mockHandler->getLastRequest()->hasHeader('Idempotency-Key'));
+
+        // POST with auto disabled → no key
+        $client->setAutoIdempotencyKey(false);
+        $client->post('/charges', ['json' => []]);
+        $this->assertFalse($this->mockHandler->getLastRequest()->hasHeader('Idempotency-Key'));
+    }
+
+    public function test_explicit_key_wins_and_custom_header_name(): void {
+        $client = $this->makeClient([new Response(200, [], '{}')]);
+        $client->setIdempotencyHeader('X-Idempotency-Token');
+
+        $client->post('/charges', ['idempotency_key' => 'my-key-123', 'json' => []]);
+
+        $sent = $this->mockHandler->getLastRequest();
+        $this->assertSame('my-key-123', $sent->getHeaderLine('X-Idempotency-Token'));
+    }
+
+    public function test_same_key_is_reused_across_retries(): void {
+        // First attempt fails with a connection error, second succeeds.
+        $client = $this->makeClient([
+            new ConnectException('boom', new Request('POST', '/charges')),
+            new Response(200, [], '{}'),
+        ]);
+        $client->setAutoIdempotencyKey(true);
+
+        $keys = [];
+        $this->mockHandler->reset();
+        $this->mockHandler->append(
+            function ($request) use (&$keys) {
+                $keys[] = $request->getHeaderLine('Idempotency-Key');
+                throw new ConnectException('boom', $request);
+            },
+            function ($request) use (&$keys) {
+                $keys[] = $request->getHeaderLine('Idempotency-Key');
+
+                return new Response(200, [], '{}');
+            }
+        );
+
+        $client->post('/charges', ['json' => []]);
+
+        $this->assertCount(2, $keys);
+        $this->assertNotSame('', $keys[0]);
+        $this->assertSame($keys[0], $keys[1], 'retry must reuse the same idempotency key');
+    }
+}

--- a/tests/ClientLogRedactionTest.php
+++ b/tests/ClientLogRedactionTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use APIToolkit\API\Authentication\ApiKeyAuthentication;
 use APIToolkit\Contracts\Abstracts\API\ClientAbstract;
 use GuzzleHttp\{Client as HttpClient, HandlerStack};
 use GuzzleHttp\Handler\MockHandler;
@@ -150,6 +151,60 @@ class ClientLogRedactionTest extends Test {
         $this->assertSame('2', $sanitized['query']['page']);
         $this->assertSame('[redacted]', $sanitized['json']['nested']['Password']);
         $this->assertSame('keep', $sanitized['json']['nested']['note']);
+    }
+
+    private function sendingRecord(): array {
+        foreach ($this->spyLogger->records as $record) {
+            if (str_starts_with($record['message'], 'Sending ')) {
+                return $record;
+            }
+        }
+
+        $this->fail('No "Sending ... request" debug record captured');
+    }
+
+    public function test_custom_auth_header_name_is_redacted(): void {
+        $client = $this->makeClient();
+        // A non-standard key header (e.g. GitLab PRIVATE-TOKEN) is not on the
+        // static SENSITIVE_HEADERS allowlist but must still be redacted.
+        $client->setAuthentication(new ApiKeyAuthentication('super-secret-key', 'PRIVATE-TOKEN'));
+
+        $client->get('/projects');
+
+        $context = $this->sendingRequestContext();
+        $this->assertSame('[redacted]', $context['headers']['PRIVATE-TOKEN']);
+        $this->assertStringNotContainsString('super-secret-key', (string) json_encode($this->spyLogger->records));
+    }
+
+    public function test_raw_string_body_is_not_logged_verbatim(): void {
+        $client = $this->makeClient();
+
+        $client->post('/login', ['body' => 'username=u&password=hunter2']);
+
+        $context = $this->sendingRequestContext();
+        $this->assertStringStartsWith('[raw body,', (string) $context['body']);
+        $this->assertStringNotContainsString('hunter2', (string) json_encode($this->spyLogger->records));
+    }
+
+    public function test_secret_in_request_uri_query_is_redacted_in_message(): void {
+        $client = $this->makeClient();
+
+        $client->get('/resource?access_token=SECRETVALUE&page=2');
+
+        $record = $this->sendingRecord();
+        $this->assertStringNotContainsString('SECRETVALUE', $record['message']);
+        $this->assertStringContainsString('page=2', $record['message']);
+    }
+
+    public function test_multipart_secret_field_is_redacted(): void {
+        $client = $this->makeClient();
+
+        $client->post('/upload', ['multipart' => [
+            ['name' => 'file', 'contents' => 'binary-data'],
+            ['name' => 'api_token', 'contents' => 'multipart-secret'],
+        ]]);
+
+        $this->assertStringNotContainsString('multipart-secret', (string) json_encode($this->spyLogger->records));
     }
 
     public function test_proxy_debug_log_strips_credentials(): void {

--- a/tests/ClientRequestAwareAuthTest.php
+++ b/tests/ClientRequestAwareAuthTest.php
@@ -149,8 +149,9 @@ class ClientRequestAwareAuthTest extends Test {
 
         $rateLimited = $this->createMock(ResponseInterface::class);
         $rateLimited->method('getStatusCode')->willReturn(429);
-        $rateLimited->method('hasHeader')->with('Retry-After')->willReturn(true);
-        $rateLimited->method('getHeaderLine')->with('Retry-After')->willReturn('120');
+        // Tolerate the client's rate-limit header probes; only Retry-After is set.
+        $rateLimited->method('hasHeader')->willReturnCallback(fn (string $name): bool => strtolower($name) === 'retry-after');
+        $rateLimited->method('getHeaderLine')->willReturnCallback(fn (string $name): string => strtolower($name) === 'retry-after' ? '120' : '');
 
         $ok = $this->createMock(ResponseInterface::class);
         $ok->method('getStatusCode')->willReturn(200);

--- a/tests/EndpointDeserializationTest.php
+++ b/tests/EndpointDeserializationTest.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : EndpointDeserializationTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\Contracts\Abstracts\API\EndpointAbstract;
+use APIToolkit\Contracts\Interfaces\API\ApiClientInterface;
+use APIToolkit\Contracts\Interfaces\NamedEntityInterface;
+use APIToolkit\Entities\Bank\IBAN;
+use APIToolkit\Entities\ID;
+use GuzzleHttp\Psr7\Response;
+use Tests\Contracts\Test;
+
+class EndpointDeserializationTest extends Test {
+    private function endpoint(ApiClientInterface $client): object {
+        return new class($client) extends EndpointAbstract {
+            protected string $endpoint = 'ibans';
+
+            public function get(?ID $id = null): ?NamedEntityInterface {
+                return $this->fetchIban();
+            }
+
+            public function fetchIban(): IBAN {
+                return $this->getEntity(IBAN::class);
+            }
+
+            /** @return array<int|string, mixed> */
+            public function fetchArray(): array {
+                return $this->getArray();
+            }
+
+            /** @param array<int, array<string, mixed>> $files */
+            public function upload(array $fields, array $files): string {
+                return $this->postMultipart($fields, $files);
+            }
+        };
+    }
+
+    public function test_get_entity_hydrates_response_into_entity(): void {
+        $client = $this->createMock(ApiClientInterface::class);
+        $client->method('get')->willReturn(new Response(200, [], '{"iban":"DE44500105175407324931"}'));
+
+        $iban = $this->endpoint($client)->fetchIban();
+
+        $this->assertInstanceOf(IBAN::class, $iban);
+        $this->assertSame('DE44500105175407324931', $iban->getValue());
+        $this->assertTrue($iban->isValid());
+    }
+
+    public function test_get_array_decodes_json_body(): void {
+        $client = $this->createMock(ApiClientInterface::class);
+        $client->method('get')->willReturn(new Response(200, [], '{"results":[1,2,3]}'));
+
+        $this->assertSame(['results' => [1, 2, 3]], $this->endpoint($client)->fetchArray());
+    }
+
+    public function test_post_multipart_builds_parts_and_returns_body(): void {
+        $client = $this->createMock(ApiClientInterface::class);
+        $captured = null;
+        $client->method('post')->willReturnCallback(function (string $uri, array $options) use (&$captured): Response {
+            $captured = $options;
+
+            return new Response(201, [], '{"ok":true}');
+        });
+
+        $body = $this->endpoint($client)->upload(
+            ['title' => 'invoice'],
+            [['name' => 'file', 'contents' => 'PDFDATA', 'filename' => 'a.pdf']]
+        );
+
+        $this->assertSame('{"ok":true}', $body);
+        $this->assertArrayHasKey('multipart', $captured);
+        $this->assertSame('title', $captured['multipart'][0]['name']);
+        $this->assertSame('file', $captured['multipart'][1]['name']);
+        $this->assertSame('a.pdf', $captured['multipart'][1]['filename']);
+    }
+}

--- a/tests/EntityRoundTripTest.php
+++ b/tests/EntityRoundTripTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : EntityRoundTripTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\Entities\Bank\{BIC, IBAN};
+use APIToolkit\Entities\Contact\EmailAddress;
+use APIToolkit\Entities\{GUID, ID, UUID, Version};
+use Tests\Contracts\Test;
+
+class EntityRoundTripTest extends Test {
+    /**
+     * toArray() must produce the entity's own key and fromArray() must accept
+     * it again — previously broken because entityName was assigned after
+     * parent::__construct(), so validateData() ran against the FQCN.
+     */
+    public function test_scalar_value_objects_round_trip_through_array(): void {
+        $cases = [
+            [new IBAN('DE44500105175407324931'), 'iban'],
+            [new BIC('INGDDEFFXXX'), 'bic'],
+            [new EmailAddress('user@example.com'), 'emailAddress'],
+            [new ID(42), 'id'],
+            [new Version(3), 'version'],
+            [new UUID('550e8400-e29b-41d4-a716-446655440000'), 'uuid'],
+            [new GUID('550e8400-e29b-41d4-a716-446655440000'), 'guid'],
+        ];
+
+        foreach ($cases as [$entity, $expectedKey]) {
+            $array = $entity->toArray();
+            $this->assertArrayHasKey($expectedKey, $array, get_class($entity) . ' should serialize under its own key');
+
+            $restored = $entity::fromArray($array);
+            $this->assertSame($entity->getValue(), $restored->getValue(), get_class($entity) . ' round-trip should preserve the value');
+        }
+    }
+}

--- a/tests/PaginatorExtensionsTest.php
+++ b/tests/PaginatorExtensionsTest.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : PaginatorExtensionsTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\API\Pagination\{LinkHeaderPaginator, OffsetPaginator};
+use GuzzleHttp\Psr7\Response;
+use Tests\Contracts\Test;
+
+class PaginatorExtensionsTest extends Test {
+    public function test_offset_paginator_stops_on_short_page(): void {
+        $pages = [
+            1 => [1, 2, 3],
+            2 => [4, 5, 6],
+            3 => [7], // short page → last
+        ];
+        $calls = [];
+
+        $paginator = new OffsetPaginator(function (int $page) use ($pages, &$calls): array {
+            $calls[] = $page;
+
+            return $pages[$page] ?? [];
+        }, pageSize: 3);
+
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7], $paginator->toArray());
+        $this->assertSame([1, 2, 3], $calls, 'must stop after the short page, not fetch page 4');
+    }
+
+    public function test_offset_paginator_stops_on_empty_first_page(): void {
+        $paginator = new OffsetPaginator(fn (int $page): array => [], pageSize: 50);
+        $this->assertSame([], $paginator->toArray());
+    }
+
+    public function test_offset_paginator_respects_max_pages(): void {
+        $paginator = new OffsetPaginator(fn (int $page): array => [$page * 10, $page * 10 + 1], pageSize: 2, startPage: 1, maxPages: 2);
+        $this->assertSame([10, 11, 20, 21], $paginator->toArray());
+    }
+
+    public function test_link_header_paginator_follows_next_until_absent(): void {
+        $responses = [
+            null => new Response(200, ['Link' => '<https://api/items?page=2>; rel="next", <https://api/items?page=3>; rel="last"'], '[1,2]'),
+            'https://api/items?page=2' => new Response(200, ['Link' => '<https://api/items?page=3>; rel="next"'], '[3,4]'),
+            'https://api/items?page=3' => new Response(200, [], '[5]'),
+        ];
+
+        $paginator = new LinkHeaderPaginator(
+            fn (?string $url): Response => $responses[$url] ?? new Response(200, [], '[]'),
+            fn ($response): array => json_decode((string) $response->getBody(), true) ?: []
+        );
+
+        $this->assertSame([1, 2, 3, 4, 5], $paginator->toArray());
+    }
+
+    public function test_parse_next_link_extracts_only_next(): void {
+        $header = '<https://api/a?page=1>; rel="prev", <https://api/a?page=3>; rel="next", <https://api/a?page=9>; rel="last"';
+        $this->assertSame('https://api/a?page=3', LinkHeaderPaginator::parseNextLink($header));
+        $this->assertNull(LinkHeaderPaginator::parseNextLink('<https://api/a?page=9>; rel="last"'));
+        $this->assertNull(LinkHeaderPaginator::parseNextLink(''));
+    }
+}

--- a/tests/TokenStoreTest.php
+++ b/tests/TokenStoreTest.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : TokenStoreTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\API\Authentication\OAuth2\{EncryptedFileTokenStore, FileTokenStore, OAuth2Token, Psr16TokenStore};
+use DateTimeImmutable;
+use Psr\SimpleCache\CacheInterface;
+use Tests\Contracts\Test;
+
+class TokenStoreTest extends Test {
+    private string $path;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->path = sys_get_temp_dir() . '/apitk-token-' . bin2hex(random_bytes(6)) . '.json';
+    }
+
+    protected function tearDown(): void {
+        @unlink($this->path);
+        parent::tearDown();
+    }
+
+    private function token(): OAuth2Token {
+        return new OAuth2Token('access-abc', 'refresh-xyz', new DateTimeImmutable('+1 hour'), 'scope-a', 'Bearer');
+    }
+
+    public function test_file_store_round_trips_and_clears(): void {
+        $store = new FileTokenStore($this->path);
+        $this->assertNull($store->load());
+
+        $store->save($this->token());
+        $loaded = $store->load();
+        $this->assertNotNull($loaded);
+        $this->assertSame('access-abc', $loaded->getAccessToken());
+        $this->assertSame('refresh-xyz', $loaded->getRefreshToken());
+
+        $this->assertSame('0600', substr(sprintf('%o', fileperms($this->path)), -4));
+
+        $store->clear();
+        $this->assertNull($store->load());
+    }
+
+    public function test_encrypted_store_does_not_persist_plaintext_tokens(): void {
+        $key = str_repeat("k", 32);
+        $store = new EncryptedFileTokenStore($this->path, $key);
+
+        $store->save($this->token());
+
+        $onDisk = (string) file_get_contents($this->path);
+        $this->assertStringNotContainsString('access-abc', $onDisk);
+        $this->assertStringNotContainsString('refresh-xyz', $onDisk);
+
+        $loaded = $store->load();
+        $this->assertNotNull($loaded);
+        $this->assertSame('access-abc', $loaded->getAccessToken());
+    }
+
+    public function test_encrypted_store_rejects_wrong_key(): void {
+        (new EncryptedFileTokenStore($this->path, str_repeat('k', 32)))->save($this->token());
+
+        $wrong = new EncryptedFileTokenStore($this->path, str_repeat('x', 32));
+        $this->assertNull($wrong->load());
+    }
+
+    public function test_psr16_store_round_trips(): void {
+        $cache = new class implements CacheInterface {
+            /** @var array<string, mixed> */
+            public array $data = [];
+
+            public function get(string $key, mixed $default = null): mixed {
+                return $this->data[$key] ?? $default;
+            }
+
+            public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool {
+                $this->data[$key] = $value;
+
+                return true;
+            }
+
+            public function delete(string $key): bool {
+                unset($this->data[$key]);
+
+                return true;
+            }
+
+            public function clear(): bool {
+                $this->data = [];
+
+                return true;
+            }
+
+            public function getMultiple(iterable $keys, mixed $default = null): iterable {
+                return [];
+            }
+
+            public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool {
+                return true;
+            }
+
+            public function deleteMultiple(iterable $keys): bool {
+                return true;
+            }
+
+            public function has(string $key): bool {
+                return isset($this->data[$key]);
+            }
+        };
+
+        $store = new Psr16TokenStore($cache, 'tenant-1:token');
+        $this->assertNull($store->load());
+
+        $store->save($this->token());
+        $this->assertSame('access-abc', $store->load()?->getAccessToken());
+
+        $store->clear();
+        $this->assertNull($store->load());
+    }
+}

--- a/tests/WebhookVerifierTest.php
+++ b/tests/WebhookVerifierTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Created on   : Wed Jul 22 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : WebhookVerifierTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\API\Webhook\WebhookVerifier;
+use InvalidArgumentException;
+use Tests\Contracts\Test;
+
+class WebhookVerifierTest extends Test {
+    private string $secret = 'whsec_test_secret';
+    private string $body = '{"event":"payment.succeeded","id":"evt_123"}';
+
+    public function test_verify_accepts_matching_hex_signature(): void {
+        $verifier = new WebhookVerifier;
+        $sig = hash_hmac('sha256', $this->body, $this->secret);
+
+        $this->assertTrue($verifier->verify($this->body, $sig, $this->secret));
+        $this->assertTrue($verifier->verify($this->body, 'sha256=' . $sig, $this->secret));
+    }
+
+    public function test_verify_accepts_matching_base64_signature(): void {
+        $verifier = new WebhookVerifier;
+        $sig = base64_encode(hash_hmac('sha256', $this->body, $this->secret, true));
+
+        $this->assertTrue($verifier->verify($this->body, $sig, $this->secret));
+    }
+
+    public function test_verify_rejects_wrong_signature_and_tampered_body(): void {
+        $verifier = new WebhookVerifier;
+        $sig = hash_hmac('sha256', $this->body, $this->secret);
+
+        $this->assertFalse($verifier->verify($this->body, 'deadbeef', $this->secret));
+        $this->assertFalse($verifier->verify($this->body . 'x', $sig, $this->secret));
+        $this->assertFalse($verifier->verify($this->body, $sig, 'wrong_secret'));
+        $this->assertFalse($verifier->verify($this->body, '', $this->secret));
+    }
+
+    public function test_verify_timestamped_accepts_fresh_signature(): void {
+        $verifier = new WebhookVerifier;
+        $ts = 1_700_000_000;
+        $sig = hash_hmac('sha256', $ts . '.' . $this->body, $this->secret);
+        $header = "t={$ts},v1={$sig}";
+
+        $this->assertTrue($verifier->verifyTimestamped($this->body, $header, $this->secret, 300, $ts + 10));
+    }
+
+    public function test_verify_timestamped_rejects_replay_outside_tolerance(): void {
+        $verifier = new WebhookVerifier;
+        $ts = 1_700_000_000;
+        $sig = hash_hmac('sha256', $ts . '.' . $this->body, $this->secret);
+        $header = "t={$ts},v1={$sig}";
+
+        $this->assertFalse($verifier->verifyTimestamped($this->body, $header, $this->secret, 300, $ts + 1000));
+    }
+
+    public function test_verify_timestamped_rejects_wrong_signature(): void {
+        $verifier = new WebhookVerifier;
+        $ts = 1_700_000_000;
+
+        $this->assertFalse($verifier->verifyTimestamped($this->body, "t={$ts},v1=deadbeef", $this->secret, 300, $ts + 10));
+        $this->assertFalse($verifier->verifyTimestamped($this->body, 'no-timestamp-here', $this->secret, 300, $ts));
+    }
+
+    public function test_constructor_rejects_unknown_algorithm(): void {
+        $this->expectException(InvalidArgumentException::class);
+        new WebhookVerifier('not-a-real-algo');
+    }
+}


### PR DESCRIPTION
Security hardening, quality fixes and feature extensions from a multi-agent audit of the toolkit family. All 289 tests green, PHPStan clean, Pint passing. Verified backward-compatible against the datev-php-sdk (1090 tests) and lexoffice-php-sdk (130 tests) — identical results vs. `main`.

## Security
- **ApiException** redacts `Set-Cookie`/authorization/`WWW-Authenticate` response headers before logging (works with any PSR-3 logger).
- **ClientAbstract**: `code`/`code_verifier` added to the redaction list; raw `body`, `multipart` fields and secrets embedded in the request URI are now redacted; custom auth header names are redacted by passing the auth header names into the sanitizer (fixes fail-open on non-standard key headers); bounded/configurable redirect following.
- Auth classes mark secret constructor params `#[\SensitiveParameter]` and add `__debugInfo()`.

## Quality
- Entity array round-trip fixed (`entityName` set before `parent::__construct`, `ID` keeps a subclass-set name); retry 502 like 503/504; consolidated retry blocks; `getEndpointUrl()` keeps a suffix without a prefix; `NamedEntity::equals()` null-guards; activated dead `StringValue`/`readOnly` logic; public-PKCE-client support; collection boilerplate removed; `CursorPaginator` catches longer cycles.

## Extensions
Idempotency keys · webhook signature verification · File/Encrypted/PSR-16 token stores · offset & Link-header paginators · OAuth2 device-code grant (RFC 8628) · response→entity hydration · multipart upload · RFC 7807 error accessors · request/response middleware hooks · rate-limit awareness · fluent `PendingRequest` builder · PSR-16 response cache with conditional requests · PSR-18/17 transport · HMAC request-signing auth.

Each change is covered by adversarial/regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
