### PR TITLE
Money-Accessoren und Hydrierungs-Härtung

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=8.1 <8.6",
         "guzzlehttp/guzzle": "^7.10",
-        "dschuppelius/php-common-toolkit": "^1.0",
+        "dschuppelius/php-common-toolkit": "^1.19",
         "dschuppelius/php-error-toolkit": "^2.4",
         "ramsey/uuid": "^4.9",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6dc8164dcd481ac2e6c44b2953bd7f12",
+    "content-hash": "9ffc9cc44fb52b2f117999e5c004e898",
     "packages": [
         {
             "name": "brick/math",

--- a/src/Contracts/Abstracts/API/ClientAbstract.php
+++ b/src/Contracts/Abstracts/API/ClientAbstract.php
@@ -217,13 +217,16 @@ abstract class ClientAbstract implements ApiClientInterface {
     /**
      * Set the minimum interval between two requests (client-side throttling).
      *
+     * Subclasses may raise the lower bound by redeclaring MIN_INTERVAL; it is
+     * resolved late (static::), so an SDK-specific rate limit actually applies.
+     *
      * @param float $requestInterval Interval in seconds (>= MIN_INTERVAL), or exactly 0.0 to disable throttling (e.g. in tests)
      */
     public function setRequestInterval(float $requestInterval): void {
-        if ($requestInterval !== 0.0 && $requestInterval < self::MIN_INTERVAL) {
+        if ($requestInterval !== 0.0 && $requestInterval < static::MIN_INTERVAL) {
             self::logErrorAndThrow(
                 InvalidArgumentException::class,
-                'Request interval must be 0 (disabled) or at least ' . self::MIN_INTERVAL . ' seconds'
+                'Request interval must be 0 (disabled) or at least ' . static::MIN_INTERVAL . ' seconds'
             );
         }
         $this->requestInterval = $requestInterval;
@@ -518,22 +521,27 @@ abstract class ClientAbstract implements ApiClientInterface {
         $this->psr18Transport = new \APIToolkit\API\Transport\Psr18Transport($client, $requestFactory, $streamFactory, $this->baseUrl);
     }
 
+    /** @param array<string, mixed> $options */
     public function get(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('GET', $uri, $options);
     }
 
+    /** @param array<string, mixed> $options */
     public function post(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('POST', $uri, $options);
     }
 
+    /** @param array<string, mixed> $options */
     public function put(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('PUT', $uri, $options);
     }
 
+    /** @param array<string, mixed> $options */
     public function patch(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('PATCH', $uri, $options);
     }
 
+    /** @param array<string, mixed> $options */
     public function delete(string $uri, array $options = []): ResponseInterface {
         return $this->requestWithRetry('DELETE', $uri, $options);
     }
@@ -660,7 +668,7 @@ abstract class ClientAbstract implements ApiClientInterface {
         if ($this->sleepAfterRequest) {
             // Sleep for MIN_INTERVAL seconds after each request to ease up on
             // rate limits (independent of the pre-request requestInterval throttle).
-            usleep((int) (self::MIN_INTERVAL * 1e6));
+            usleep((int) (static::MIN_INTERVAL * 1e6));
         }
 
         if ($response->getStatusCode() >= 400) {

--- a/src/Contracts/Abstracts/API/EndpointAbstract.php
+++ b/src/Contracts/Abstracts/API/EndpointAbstract.php
@@ -50,7 +50,7 @@ abstract class EndpointAbstract implements EndpointInterface {
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<int|string, mixed> $data
      * @param array<string, mixed> $options
      * @param int|array<int, int> $statusCode
      */
@@ -65,7 +65,7 @@ abstract class EndpointAbstract implements EndpointInterface {
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<int|string, mixed> $data
      * @param array<string, mixed> $options
      * @param int|array<int, int> $statusCode
      */
@@ -80,7 +80,7 @@ abstract class EndpointAbstract implements EndpointInterface {
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<int|string, mixed> $data
      * @param array<string, mixed> $options
      * @param int|array<int, int> $statusCode
      */
@@ -134,7 +134,10 @@ abstract class EndpointAbstract implements EndpointInterface {
      * @return T
      */
     protected function getEntity(string $entityClass, array $queryParams = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): NamedEntityInterface {
-        return $entityClass::fromJson($this->getContents($queryParams, $options, $urlPath, $statusCode));
+        /** @var T $entity */
+        $entity = $entityClass::fromJson($this->getContents($queryParams, $options, $urlPath, $statusCode));
+
+        return $entity;
     }
 
     /**
@@ -142,13 +145,16 @@ abstract class EndpointAbstract implements EndpointInterface {
      *
      * @template T of NamedEntityInterface
      * @param class-string<T> $entityClass
-     * @param array<string, mixed> $data
+     * @param array<int|string, mixed> $data
      * @param array<string, mixed> $options
      * @param int|array<int, int> $statusCode
      * @return T
      */
     protected function postEntity(string $entityClass, array $data = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 201): NamedEntityInterface {
-        return $entityClass::fromJson($this->postContents($data, $options, $urlPath, $statusCode));
+        /** @var T $entity */
+        $entity = $entityClass::fromJson($this->postContents($data, $options, $urlPath, $statusCode));
+
+        return $entity;
     }
 
     /**
@@ -156,13 +162,16 @@ abstract class EndpointAbstract implements EndpointInterface {
      *
      * @template T of NamedEntityInterface
      * @param class-string<T> $entityClass
-     * @param array<string, mixed> $data
+     * @param array<int|string, mixed> $data
      * @param array<string, mixed> $options
      * @param int|array<int, int> $statusCode
      * @return T
      */
     protected function putEntity(string $entityClass, array $data = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): NamedEntityInterface {
-        return $entityClass::fromJson($this->putContents($data, $options, $urlPath, $statusCode));
+        /** @var T $entity */
+        $entity = $entityClass::fromJson($this->putContents($data, $options, $urlPath, $statusCode));
+
+        return $entity;
     }
 
     /**
@@ -170,13 +179,16 @@ abstract class EndpointAbstract implements EndpointInterface {
      *
      * @template T of NamedEntityInterface
      * @param class-string<T> $entityClass
-     * @param array<string, mixed> $data
+     * @param array<int|string, mixed> $data
      * @param array<string, mixed> $options
      * @param int|array<int, int> $statusCode
      * @return T
      */
     protected function patchEntity(string $entityClass, array $data = [], array $options = [], ?string $urlPath = null, int|array $statusCode = 200): NamedEntityInterface {
-        return $entityClass::fromJson($this->patchContents($data, $options, $urlPath, $statusCode));
+        /** @var T $entity */
+        $entity = $entityClass::fromJson($this->patchContents($data, $options, $urlPath, $statusCode));
+
+        return $entity;
     }
 
     /**

--- a/src/Contracts/Abstracts/NamedEntity.php
+++ b/src/Contracts/Abstracts/NamedEntity.php
@@ -32,6 +32,9 @@ abstract class NamedEntity implements NamedEntityInterface {
     protected string $entityName = '';
     protected string $valueClassName = '';
 
+    /**
+     * @param array<string, mixed>|object|null $data
+     */
     public function __construct(array|object|null $data = null, ?LoggerInterface $logger = null) {
         $this->entityName = static::class;
         $this->initializeLogger($logger);
@@ -47,6 +50,9 @@ abstract class NamedEntity implements NamedEntityInterface {
         return $this->entityName;
     }
 
+    /**
+     * @param array<string, mixed>|object $data
+     */
     public function setData(array|object $data): NamedEntityInterface {
         if (is_object($data)) {
             $data = (array) $data;
@@ -86,12 +92,7 @@ abstract class NamedEntity implements NamedEntityInterface {
 
         if (array_key_exists($typeName, $filterMap) && !is_null($val)) {
             if ($typeName === 'float' && is_string($val)) {
-                if (preg_match('/^\d{1,3}(\.\d{3})*(,\d+)?$/', $val)) {
-                    $val = str_replace('.', '', $val);
-                    $val = str_replace(',', '.', $val);
-                } elseif (preg_match('/^\d+,\d+$/', $val)) {
-                    $val = str_replace(',', '.', $val);
-                }
+                $val = self::normalizeDecimalString($val);
             }
 
             $this->{$key} = filter_var($val, $filterMap[$typeName], FILTER_NULL_ON_FAILURE);
@@ -122,6 +123,28 @@ abstract class NamedEntity implements NamedEntityInterface {
         }
     }
 
+    /**
+     * Normalize a decimal written in European notation to the format
+     * filter_var() understands.
+     *
+     * Only a comma makes the notation unambiguous ("1.234,56" → 1234.56,
+     * "12,5" → 12.5). Without one, the string is passed through untouched:
+     * "1.234" is a decimal point in every JSON API that is not explicitly
+     * German, and guessing a thousands separator there was off by a factor
+     * of 1000.
+     */
+    protected static function normalizeDecimalString(string $value): string {
+        if (!str_contains($value, ',')) {
+            return $value;
+        }
+
+        if (preg_match('/^-?\d{1,3}(\.\d{3})*(,\d+)?$/', $value) || preg_match('/^-?\d+,\d+$/', $value)) {
+            return str_replace(',', '.', str_replace('.', '', $value));
+        }
+
+        return $value;
+    }
+
     protected function handleComplexType(string $key, mixed $val, ReflectionNamedType $type): void {
         $className = $type->getName();
 
@@ -129,7 +152,17 @@ abstract class NamedEntity implements NamedEntityInterface {
             try {
                 $this->{$key} = $className::from($val);
             } catch (Throwable $e) {
+                // A value the enum does not know (typically a case the API
+                // added later) must not leave the property uninitialized —
+                // that surfaces as a fatal "must not be accessed before
+                // initialization" somewhere far away from the cause.
                 self::logException($e, context: ['property' => $key, 'class' => $className]);
+
+                if (!$type->allowsNull()) {
+                    throw new UnexpectedValueException("Unknown value for enum $className in property $key: " . var_export($val, true));
+                }
+
+                $this->{$key} = null;
             }
         } elseif ($key == "content" && !empty($this->valueClassName) && is_subclass_of($className, NamedEntityInterface::class)) {
             $this->{$key} = new $this->valueClassName($val, self::$logger);
@@ -343,6 +376,9 @@ abstract class NamedEntity implements NamedEntityInterface {
         return true; // Wenn alle Eigenschaften gleich sind, sind die Objekte gleich
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array {
         return $this->getArray();
     }
@@ -351,6 +387,9 @@ abstract class NamedEntity implements NamedEntityInterface {
         return json_encode($this->toArray(), $flags | JSON_THROW_ON_ERROR);
     }
 
+    /**
+     * @param array<int|string, mixed> $data
+     */
     public static function fromArray(array $data, ?LoggerInterface $logger = null): static {
         $className = get_called_class();
         return new $className($data, $logger);

--- a/src/Traits/MoneyAccessorTrait.php
+++ b/src/Traits/MoneyAccessorTrait.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : MoneyAccessorTrait.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\Traits;
+
+use CommonToolkit\Enums\CurrencyCode;
+use CommonToolkit\ValueObjects\Money;
+
+/**
+ * Geldbeträge von API-Entities.
+ *
+ * REST-APIs liefern Beträge als JSON-Zahlen; die Hydrierung legt sie deshalb
+ * weiterhin als float ab (mehr Genauigkeit hat die Quelle nicht). **Gelesen**
+ * wird ausschließlich {@see Money}: die Umwandlung passiert an dieser einen
+ * Stelle, inklusive Währung — ab dort rechnet der Aufrufer exakt.
+ *
+ * Die Belegwährung wird aus dem ersten gefundenen Währungsfeld der Entity
+ * gelesen; ein SDK mit abweichender Feldbenennung überschreibt dafür
+ * {@see currencyFieldCandidates()}, ein SDK mit anderer Standardwährung
+ * {@see defaultCurrency()}.
+ */
+trait MoneyAccessorTrait {
+    /**
+     * Rohbetrag der API → Money in der Belegwährung (null bleibt null).
+     */
+    protected function toMoney(?float $amount, ?CurrencyCode $currency = null): ?Money {
+        if ($amount === null) {
+            return null;
+        }
+
+        return Money::ofFloat($amount, $currency ?? $this->entityCurrency());
+    }
+
+    /**
+     * Belegwährung der Entity; ohne eigenes Feld gilt defaultCurrency().
+     */
+    protected function entityCurrency(): CurrencyCode {
+        foreach ($this->currencyFieldCandidates() as $field) {
+            if (!property_exists($this, $field) || !isset($this->{$field})) {
+                continue;
+            }
+
+            $value = $this->{$field};
+            if ($value instanceof CurrencyCode) {
+                return $value;
+            }
+            if (is_string($value) && $value !== '') {
+                return CurrencyCode::tryFrom(strtoupper($value)) ?? $this->defaultCurrency();
+            }
+        }
+
+        return $this->defaultCurrency();
+    }
+
+    /**
+     * Property-Namen, unter denen die Entity ihre Währung führen kann.
+     *
+     * @return array<int, string>
+     */
+    protected function currencyFieldCandidates(): array {
+        return ['currency', 'currencyCode', 'currency_code', 'waehrung'];
+    }
+
+    /**
+     * Währung, wenn die Entity keine eigene führt — deutschsprachige
+     * Buchhaltungs-APIs rechnen in Euro.
+     */
+    protected function defaultCurrency(): CurrencyCode {
+        return CurrencyCode::Euro;
+    }
+}

--- a/tests/ClientExtensionsTest.php
+++ b/tests/ClientExtensionsTest.php
@@ -17,11 +17,23 @@ use APIToolkit\Contracts\Abstracts\API\ClientAbstract;
 use GuzzleHttp\{Client as HttpClient, HandlerStack};
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\{HttpFactory, Response};
+use Psr\Http\Message\RequestInterface;
 use Psr\SimpleCache\CacheInterface;
 use Tests\Contracts\Test;
 
 class ClientExtensionsTest extends Test {
     private MockHandler $mockHandler;
+
+    /**
+     * Der zuletzt gesendete Request. MockHandler::getLastRequest() ist
+     * nullable; nach einem abgesetzten Aufruf ist er es nie.
+     */
+    private function lastRequest(): RequestInterface {
+        $request = $this->mockHandler->getLastRequest();
+        $this->assertNotNull($request);
+
+        return $request;
+    }
 
     /**
      * @param array<int, Response> $queue
@@ -110,8 +122,7 @@ class ClientExtensionsTest extends Test {
 
         $client->get('/x');
 
-        $sent = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($sent);
+        $sent = $this->lastRequest();
         $this->assertSame('abc-123', $sent->getHeaderLine('X-Trace'));
     }
 
@@ -132,8 +143,7 @@ class ClientExtensionsTest extends Test {
             ->withIdempotencyKey('key-9')
             ->post('/charges');
 
-        $sent = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($sent);
+        $sent = $this->lastRequest();
         $this->assertSame('application/json', $sent->getHeaderLine('Accept'));
         $this->assertSame('key-9', $sent->getHeaderLine('Idempotency-Key'));
         $this->assertSame('{"amount":100}', (string) $sent->getBody());
@@ -162,8 +172,7 @@ class ClientExtensionsTest extends Test {
         $client->get('/data');
         $second = $client->get('/data');
 
-        $sent = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($sent);
+        $sent = $this->lastRequest();
         $this->assertSame('"abc"', $sent->getHeaderLine('If-None-Match'));
         $this->assertSame('{"v":1}', (string) $second->getBody()); // 304 served from cache
     }
@@ -176,8 +185,7 @@ class ClientExtensionsTest extends Test {
         $response = $client->post('/charges', ['json' => ['a' => 1]]);
 
         $this->assertSame('{"ok":true}', (string) $response->getBody());
-        $sent = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($sent);
+        $sent = $this->lastRequest();
         $this->assertSame('POST', $sent->getMethod());
         $this->assertStringContainsString('application/json', $sent->getHeaderLine('Content-Type'));
         $this->assertSame('{"a":1}', (string) $sent->getBody());

--- a/tests/ClientIdempotencyTest.php
+++ b/tests/ClientIdempotencyTest.php
@@ -17,10 +17,22 @@ use GuzzleHttp\{Client as HttpClient, HandlerStack};
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\{Request, Response};
+use Psr\Http\Message\RequestInterface;
 use Tests\Contracts\Test;
 
 class ClientIdempotencyTest extends Test {
     private MockHandler $mockHandler;
+
+    /**
+     * Der zuletzt gesendete Request. MockHandler::getLastRequest() ist
+     * nullable; nach einem abgesetzten Aufruf ist er es nie.
+     */
+    private function lastRequest(): RequestInterface {
+        $request = $this->mockHandler->getLastRequest();
+        $this->assertNotNull($request);
+
+        return $request;
+    }
 
     /**
      * @param array<int, \Psr\Http\Message\ResponseInterface|\Throwable|callable> $queue
@@ -42,8 +54,7 @@ class ClientIdempotencyTest extends Test {
 
         $client->post('/charges', ['json' => ['amount' => 100]]);
 
-        $sent = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($sent);
+        $sent = $this->lastRequest();
         $this->assertTrue($sent->hasHeader('Idempotency-Key'));
         $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $sent->getHeaderLine('Idempotency-Key'));
     }
@@ -54,15 +65,13 @@ class ClientIdempotencyTest extends Test {
         // GET with auto enabled → still no key (GET is not mutating)
         $client->setAutoIdempotencyKey(true);
         $client->get('/charges');
-        $getRequest = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($getRequest);
+        $getRequest = $this->lastRequest();
         $this->assertFalse($getRequest->hasHeader('Idempotency-Key'));
 
         // POST with auto disabled → no key
         $client->setAutoIdempotencyKey(false);
         $client->post('/charges', ['json' => []]);
-        $postRequest = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($postRequest);
+        $postRequest = $this->lastRequest();
         $this->assertFalse($postRequest->hasHeader('Idempotency-Key'));
     }
 
@@ -72,8 +81,7 @@ class ClientIdempotencyTest extends Test {
 
         $client->post('/charges', ['idempotency_key' => 'my-key-123', 'json' => []]);
 
-        $sent = $this->mockHandler->getLastRequest();
-        $this->assertNotNull($sent);
+        $sent = $this->lastRequest();
         $this->assertSame('my-key-123', $sent->getHeaderLine('X-Idempotency-Token'));
     }
 

--- a/tests/Contracts/Test.php
+++ b/tests/Contracts/Test.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 abstract class Test extends TestCase {
-    protected ?LoggerInterface $logger = null;
+    protected LoggerInterface $logger;
 
     protected function setUp(): void {
         parent::setUp();

--- a/tests/HydrationRobustnessTest.php
+++ b/tests/HydrationRobustnessTest.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : HydrationRobustnessTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use APIToolkit\Contracts\Abstracts\API\ClientAbstract;
+use Tests\Contracts\Test;
+use Tests\TestEntities\{CheckerStatus, EnumChecker, FloatChecker};
+use UnexpectedValueException;
+
+class HydrationRobustnessTest extends Test {
+    public function test_decimal_point_is_not_mistaken_for_a_thousands_separator(): void {
+        // Ohne Komma ist "1.234" in jeder nicht explizit deutschen API ein
+        // Dezimalpunkt — die frühere Heuristik machte daraus 1234.0.
+        $checker = new FloatChecker(['floatVar1' => '1.234'], $this->logger);
+
+        $this->assertSame(1.234, $checker->getFloatVar1());
+    }
+
+    public function test_german_notation_with_comma_is_still_normalized(): void {
+        $checker = new FloatChecker([
+            'floatVar1' => '1.234,56',
+            'floatVar2' => '12,5',
+            'floatVar3' => '1234.56',
+        ], $this->logger);
+
+        $this->assertSame(1234.56, $checker->getFloatVar1());
+        $this->assertSame(12.5, $checker->getFloatVar2());
+        $this->assertSame(1234.56, $checker->getFloatVar3());
+    }
+
+    public function test_unknown_enum_value_nulls_a_nullable_property(): void {
+        $checker = new EnumChecker(['nullableStatus' => 'value-the-api-added-later'], $this->logger);
+
+        $this->assertNull($checker->getNullableStatus());
+    }
+
+    public function test_unknown_enum_value_fails_loudly_for_a_required_property(): void {
+        // Zuvor blieb die Property uninitialisiert und schlug erst beim
+        // Zugriff an ganz anderer Stelle als Fatal auf.
+        $this->expectException(UnexpectedValueException::class);
+
+        new EnumChecker(['requiredStatus' => 'value-the-api-added-later'], $this->logger);
+    }
+
+    public function test_known_enum_values_still_hydrate(): void {
+        $checker = new EnumChecker(['nullableStatus' => 'open', 'requiredStatus' => 'closed'], $this->logger);
+
+        $this->assertSame(CheckerStatus::Open, $checker->getNullableStatus());
+        $this->assertSame(CheckerStatus::Closed, $checker->getRequiredStatus());
+    }
+
+    public function test_subclass_may_raise_the_minimum_request_interval(): void {
+        $client = new class('https://api.example.com') extends ClientAbstract {
+            public const MIN_INTERVAL = 0.5;
+        };
+
+        // Die Untergrenze der Subklasse gilt (zuvor löste self:: immer die
+        // 0.2 der Basisklasse auf, die SDK-Vorgabe war wirkungslos).
+        $this->expectException(\InvalidArgumentException::class);
+        $client->setRequestInterval(0.3);
+    }
+
+    public function test_subclass_minimum_still_allows_disabling_and_higher_values(): void {
+        $client = new class('https://api.example.com') extends ClientAbstract {
+            public const MIN_INTERVAL = 0.5;
+        };
+
+        $client->setRequestInterval(0.0);
+        $this->assertSame(0.0, $client->getRequestInterval());
+
+        $client->setRequestInterval(0.65);
+        $this->assertSame(0.65, $client->getRequestInterval());
+    }
+}

--- a/tests/MoneyAccessorTest.php
+++ b/tests/MoneyAccessorTest.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : MoneyAccessorTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use CommonToolkit\Enums\CurrencyCode;
+use Tests\Contracts\Test;
+use Tests\TestEntities\MoneyCarrier;
+
+class MoneyAccessorTest extends Test {
+    public function test_null_stays_null(): void {
+        $entity = $this->entityWithoutCurrency();
+
+        $this->assertNull($entity->total(null));
+    }
+
+    public function test_amount_without_currency_field_falls_back_to_euro(): void {
+        $money = $this->entityWithoutCurrency()->total(19.99);
+
+        $this->assertNotNull($money);
+        $this->assertSame(CurrencyCode::Euro, $money->getCurrency());
+        $this->assertSame('19.99', (string) $money->getAmount());
+    }
+
+    public function test_currency_enum_property_wins(): void {
+        $money = $this->entityWithCurrency(CurrencyCode::SwissFranc)->total(10.0);
+
+        $this->assertNotNull($money);
+        $this->assertSame(CurrencyCode::SwissFranc, $money->getCurrency());
+    }
+
+    public function test_currency_string_property_is_resolved(): void {
+        $money = $this->entityWithCurrency('usd')->total(10.0);
+
+        $this->assertNotNull($money);
+        $this->assertSame(CurrencyCode::USDollar, $money->getCurrency());
+    }
+
+    public function test_unknown_currency_string_falls_back_to_default(): void {
+        $money = $this->entityWithCurrency('XYZ')->total(10.0);
+
+        $this->assertNotNull($money);
+        $this->assertSame(CurrencyCode::Euro, $money->getCurrency());
+    }
+
+    public function test_explicit_currency_overrides_the_entity_currency(): void {
+        $money = $this->entityWithCurrency(CurrencyCode::SwissFranc)->total(10.0, CurrencyCode::USDollar);
+
+        $this->assertNotNull($money);
+        $this->assertSame(CurrencyCode::USDollar, $money->getCurrency());
+    }
+
+    private function entityWithoutCurrency(): MoneyCarrier {
+        return new MoneyCarrier;
+    }
+
+    private function entityWithCurrency(CurrencyCode|string $currency): MoneyCarrier {
+        return new MoneyCarrier($currency);
+    }
+}

--- a/tests/TestEntities/CheckerStatus.php
+++ b/tests/TestEntities/CheckerStatus.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : CheckerStatus.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests\TestEntities;
+
+enum CheckerStatus: string {
+    case Open = 'open';
+    case Closed = 'closed';
+}

--- a/tests/TestEntities/EnumChecker.php
+++ b/tests/TestEntities/EnumChecker.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : EnumChecker.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests\TestEntities;
+
+use APIToolkit\Contracts\Abstracts\NamedEntity;
+use Psr\Log\LoggerInterface;
+
+class EnumChecker extends NamedEntity {
+    protected ?CheckerStatus $nullableStatus;
+    protected CheckerStatus $requiredStatus;
+
+    /**
+     * @param array<string, mixed>|object|null $data
+     */
+    public function __construct($data = null, ?LoggerInterface $logger = null) {
+        parent::__construct($data, $logger);
+    }
+
+    public function getNullableStatus(): ?CheckerStatus {
+        return $this->nullableStatus ?? null;
+    }
+
+    public function getRequiredStatus(): ?CheckerStatus {
+        return $this->requiredStatus ?? null;
+    }
+}

--- a/tests/TestEntities/MoneyCarrier.php
+++ b/tests/TestEntities/MoneyCarrier.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : MoneyCarrier.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests\TestEntities;
+
+use APIToolkit\Traits\MoneyAccessorTrait;
+use CommonToolkit\Enums\CurrencyCode;
+use CommonToolkit\ValueObjects\Money;
+
+class MoneyCarrier {
+    use MoneyAccessorTrait;
+
+    protected CurrencyCode|string|null $currency;
+
+    public function __construct(CurrencyCode|string|null $currency = null) {
+        $this->currency = $currency;
+    }
+
+    public function total(?float $amount, ?CurrencyCode $explicitCurrency = null): ?Money {
+        return $this->toMoney($amount, $explicitCurrency);
+    }
+}


### PR DESCRIPTION
Setzt den lokalen Commit `b047a76 "Hardening und Money"` auf den aktuellen main-Stand. Der Ursprungs-Branch `audit/security-hardening` war nach dem Merge von #23 remote gelöscht; die parallel auf main gelandete PHPStan-Level-8-Härtung (#22) hat dieselben Dateien angefasst, deshalb ein frischer Branch.

## Inhalt

**`MoneyAccessorTrait` (neu)** — API-Beträge werden weiterhin als `float` hydriert (mehr Genauigkeit hat die Quelle nicht), aber ausschließlich als `Money` gelesen. Die Umwandlung inkl. Belegwährung passiert an einer Stelle; Währungsfeld (`currencyFieldCandidates()`) und Standardwährung (`defaultCurrency()`) sind je SDK überschreibbar.

**`NamedEntity`-Hydrierung**
- `normalizeDecimalString()`: `"1.234"` wird nicht mehr als Tausendertrennzeichen gelesen. Nur ein Komma macht die Notation eindeutig — ohne Komma lag die Umwandlung um den Faktor 1000 daneben.
- Unbekannte Enum-Werte (typischerweise ein später ergänzter API-Case) lassen die Property nicht mehr uninitialisiert zurück. Das schlug vorher als Fatal weit entfernt von der Ursache auf; jetzt `null` bzw. `UnexpectedValueException` bei nicht-nullable Typ.

**`ClientAbstract`** — `MIN_INTERVAL` über `static::` statt `self::`, damit SDKs ein eigenes Mindestintervall setzen können.

**`composer.json`** — `dschuppelius/php-common-toolkit` von `^1.0` auf `^1.19` angehoben: `Money::ofFloat` gibt es erst ab v1.19, mit einer älteren 1.x würde der neue Trait fatal brechen.

## Bewusst nicht übernommen

Die im Ursprungscommit enthaltene zweite PHPStan-Level-8-Runde wurde zugunsten der bereits auf main gemergten Variante (#22) verworfen — u. a. bleiben `@template-covariant` in `NamedValues`, der defensive `instanceof`-Check in `NamedValues::equals()` und der `StringValues::toArray()`-Fallback für rohe Skalare erhalten (`validateData()` legt Nicht-Entities in `$values` ab).

## Prüfung

- PHPUnit: 307 Tests, 762 Assertions — grün
- PHPStan Level 8 (src + tests): keine Fehler
- Pint: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)