### PR TITLE
Gemeinsame Test- und Paginierungsbausteine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,33 @@ A reusable PHP library for building API client SDKs, targeting PHP 8.2+ with mod
 - **Default Headers & Query Params** - Global request configuration
 - **SSL Control** - Optional SSL verification bypass for development
 
+## Building blocks
+
+The toolkit carries more than the client base class. Which of these an SDK
+needs depends on the API it wraps — the ones an SDK does not use are meant for
+the *application* embedding it, not dead weight:
+
+| Building block | Use it for | Used by the SDKs |
+| --- | --- | --- |
+| `Contracts\Abstracts\API\ClientAbstract` | client base: throttling, retry, log redaction | all |
+| `Contracts\Abstracts\API\EndpointAbstract` | endpoint base: request helpers, response hydration | all |
+| `Contracts\Abstracts\API\PagedEndpointAbstract` | `searchAll()` over page/size or limit/offset APIs | lexoffice, orgamax |
+| `API\Pagination\OffsetPaginator` | page-number / offset pagination | via PagedEndpointAbstract |
+| `API\Pagination\LinkHeaderPaginator`, `LinkHeader` | RFC 8288 `Link` header pagination | datev |
+| `API\Pagination\CursorPaginator` | cursor/continuation-token pagination | — (no API needs it yet) |
+| `API\Authentication\*` | Bearer, Basic, API key, HMAC, OAuth2 grants | Bearer/Basic (all), OAuth2 (datev) |
+| `Contracts\Interfaces\API\RefreshableAuthenticationInterface` | self-healing credentials after a 401 | orgamax |
+| `API\Webhook\WebhookVerifier` | verifying inbound webhook signatures | — application-side, see below |
+| `API\Cache\Psr16ResponseCache` | conditional requests / response caching | — application-side |
+| `API\PendingRequest` | fluent one-off requests outside an endpoint | — application-side |
+| `API\Transport\Psr18Transport` | routing through a PSR-18 client instead of Guzzle | — application-side |
+| `Testing\MockApiClient` | endpoint tests without HTTP | lexoffice, orgamax |
+
+**Application-side** means: an SDK exposes the API surface, but signature
+verification, caching and transport choice belong to the application that
+receives the webhooks, owns the cache and picks the HTTP stack. Wiring them
+into an SDK would decide those questions for every consumer.
+
 ## Installation
 
 ```bash
@@ -317,6 +344,23 @@ try {
 | 504 | `GatewayTimeoutException` |
 
 ## Testing
+
+`Testing\MockApiClient` implements `ApiClientInterface` and answers registered
+method/URI patterns, so endpoint logic can be tested without HTTP:
+
+```php
+$client = (new APIToolkit\Testing\MockApiClient())
+    ->addResponse('GET', 'article/90', 200, '{"id":90}')
+    ->addResponse('*', 'invoice/*', 204, '');
+
+$article = (new ArticlesEndpoint($client))->get(new ID(90));
+$client->getLastRequest(); // ['method' => 'GET', 'uri' => 'article/90', 'options' => []]
+```
+
+It covers endpoint behaviour, **not** the transport. URL building, headers,
+auth and retry only get exercised by a test against the real client with an
+injected Guzzle `MockHandler` — that is the layer where a swallowed base path
+or a wrong `Content-Type` hides.
 
 ```bash
 composer test

--- a/src/API/Pagination/LinkHeader.php
+++ b/src/API/Pagination/LinkHeader.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : LinkHeader.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\API\Pagination;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Parser für Link-Header nach RFC 8288 (vormals RFC 5988):
+ * `<url1>; rel="next", <url2>; rel="last"`.
+ *
+ * Eine Implementierung für alle Nutzer — der {@see LinkHeaderPaginator} folgt
+ * damit rel="next", SDKs reichen die übrigen Relationen an ihre Aufrufer
+ * weiter.
+ */
+final class LinkHeader {
+    /**
+     * Alle Relationen eines Link-Headers.
+     *
+     * @return array<string, string> rel => URL
+     */
+    public static function parse(string $linkHeader): array {
+        $links = [];
+
+        if (trim($linkHeader) === '') {
+            return $links;
+        }
+
+        foreach (explode(',', $linkHeader) as $part) {
+            if (preg_match('/<\s*([^>]+?)\s*>\s*;\s*(.+)/', trim($part), $matches) !== 1) {
+                continue;
+            }
+
+            if (preg_match('/rel\s*=\s*"?\s*([^";\s]+)\s*"?/i', $matches[2], $rel) !== 1) {
+                continue;
+            }
+
+            $links[strtolower($rel[1])] = trim($matches[1]);
+        }
+
+        return $links;
+    }
+
+    /**
+     * @return array<string, string> rel => URL
+     */
+    public static function fromResponse(ResponseInterface $response): array {
+        return self::parse($response->getHeaderLine('Link'));
+    }
+
+    /** Ziel der Relation rel="next", oder null. */
+    public static function next(string $linkHeader): ?string {
+        return self::parse($linkHeader)['next'] ?? null;
+    }
+}

--- a/src/API/Pagination/LinkHeaderPaginator.php
+++ b/src/API/Pagination/LinkHeaderPaginator.php
@@ -95,19 +95,6 @@ class LinkHeaderPaginator implements IteratorAggregate {
      * Extract the rel="next" target from an RFC 8288 Link header, or null.
      */
     public static function parseNextLink(string $linkHeader): ?string {
-        if ($linkHeader === '') {
-            return null;
-        }
-
-        foreach (explode(',', $linkHeader) as $part) {
-            if (preg_match('/<\s*([^>]+)\s*>\s*;\s*(.+)/', trim($part), $m) !== 1) {
-                continue;
-            }
-            if (preg_match('/rel\s*=\s*"?\s*next\s*"?/i', $m[2]) === 1) {
-                return trim($m[1]);
-            }
-        }
-
-        return null;
+        return LinkHeader::next($linkHeader);
     }
 }

--- a/src/Contracts/Abstracts/API/PagedEndpointAbstract.php
+++ b/src/Contracts/Abstracts/API/PagedEndpointAbstract.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : PagedEndpointAbstract.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\Contracts\Abstracts\API;
+
+use APIToolkit\API\Pagination\OffsetPaginator;
+use Generator;
+
+/**
+ * Basis für Endpoints mit seitenweiser Suche.
+ *
+ * searchAll() läuft die Seiten über den {@see OffsetPaginator} durch und gibt
+ * die einzelnen Einträge aus; Aufrufer führen weder Seitenzähler noch
+ * Abbruchbedingung selbst. Wie eine Seite adressiert wird, entscheidet das
+ * SDK über {@see pageQueryParams()} — seitennummern-basierte APIs
+ * (page/size) und offset-basierte (limit/offset) unterscheiden sich nur darin.
+ */
+abstract class PagedEndpointAbstract extends EndpointAbstract {
+    /** Obergrenze der Einträge je Anfrage; von der API vorgegeben. */
+    public const MAX_PAGE_SIZE = 250;
+
+    public const DEFAULT_PAGE_SIZE = 100;
+
+    /** Nummer der ersten Seite (0 bei nullbasierten APIs). */
+    protected const FIRST_PAGE = 0;
+
+    /**
+     * Query-Parameter für eine Seite.
+     *
+     * @param int $page Nullbasierter Seitenindex
+     * @return array<string, mixed>
+     */
+    abstract protected function pageQueryParams(int $page, int $pageSize): array;
+
+    /**
+     * Die Einträge einer Seiten-Antwort.
+     *
+     * @param array<string, mixed> $queryParams
+     * @param array<string, mixed> $options
+     * @return array<int, mixed>
+     */
+    abstract protected function pageItems(array $queryParams, array $options): array;
+
+    /**
+     * Iteriert alle Treffer einer Suche über sämtliche Seiten hinweg.
+     *
+     * @param array<string, mixed> $queryParams Suchparameter ohne Seitenangaben
+     * @param array<string, mixed> $options
+     * @param int|null $maxPages Obergrenze für die Zahl geladener Seiten
+     * @return Generator<int, mixed>
+     */
+    public function searchAll(array $queryParams = [], int $pageSize = self::DEFAULT_PAGE_SIZE, array $options = [], ?int $maxPages = null): Generator {
+        $pageSize = max(1, min($pageSize, static::MAX_PAGE_SIZE));
+
+        $paginator = new OffsetPaginator(
+            fn (int $page): array => $this->pageItems(
+                array_merge($queryParams, $this->pageQueryParams($page, $pageSize)),
+                $options
+            ),
+            $pageSize,
+            static::FIRST_PAGE,
+            $maxPages
+        );
+
+        yield from $paginator;
+    }
+}

--- a/src/Testing/MockApiClient.php
+++ b/src/Testing/MockApiClient.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : MockApiClient.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\Testing;
+
+use APIToolkit\Contracts\Interfaces\API\ApiClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Client-Attrappe für Endpoint-Tests: registrierte Antworten je Methode und
+ * URI-Muster, dazu ein Protokoll der abgesetzten Aufrufe.
+ *
+ * Deckt die Fachlogik der Endpoints ab, **nicht** die Transportschicht — für
+ * URL-Bau, Header, Auth und Retry gehört ein Test mit injiziertem
+ * Guzzle-MockHandler gegen den echten Client daneben.
+ */
+class MockApiClient implements ApiClientInterface {
+    /** @var array<string, array{statusCode: int, body: string, headers: array<string, mixed>}> */
+    private array $responses = [];
+
+    /** @var array<array{method: string, uri: string, options: array<string, mixed>}> */
+    private array $requestLog = [];
+
+    private int $defaultStatusCode = 200;
+
+    private string $defaultBody = '{}';
+
+    /**
+     * Registriert eine Antwort für Methode und URI-Muster.
+     *
+     * @param string $method HTTP-Methode (GET, POST, PUT, DELETE, PATCH) oder '*' für jede
+     * @param string $uriPattern URI-Muster, optional mit Platzhaltern (*)
+     * @param array<string, mixed> $headers
+     */
+    public function addResponse(string $method, string $uriPattern, int $statusCode, string $body, array $headers = []): self {
+        $key = strtoupper($method) . ':' . $uriPattern;
+        $this->responses[$key] = [
+            'statusCode' => $statusCode,
+            'body' => $body,
+            'headers' => array_merge(['Content-Type' => 'application/json'], $headers),
+        ];
+
+        return $this;
+    }
+
+    /** Antwort für URIs ohne passendes Muster. */
+    public function setDefaultResponse(int $statusCode, string $body): self {
+        $this->defaultStatusCode = $statusCode;
+        $this->defaultBody = $body;
+
+        return $this;
+    }
+
+    /**
+     * @return array<array{method: string, uri: string, options: array<string, mixed>}>
+     */
+    public function getRequestLog(): array {
+        return $this->requestLog;
+    }
+
+    /**
+     * @return array{method: string, uri: string, options: array<string, mixed>}|null
+     */
+    public function getLastRequest(): ?array {
+        return $this->requestLog[count($this->requestLog) - 1] ?? null;
+    }
+
+    public function clearRequestLog(): void {
+        $this->requestLog = [];
+    }
+
+    public function clearResponses(): void {
+        $this->responses = [];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function get(string $uri, array $options = []): ResponseInterface {
+        return $this->request('GET', $uri, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function post(string $uri, array $options = []): ResponseInterface {
+        return $this->request('POST', $uri, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function put(string $uri, array $options = []): ResponseInterface {
+        return $this->request('PUT', $uri, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function patch(string $uri, array $options = []): ResponseInterface {
+        return $this->request('PATCH', $uri, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function delete(string $uri, array $options = []): ResponseInterface {
+        return $this->request('DELETE', $uri, $options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function request(string $method, string $uri, array $options): ResponseInterface {
+        $this->requestLog[] = [
+            'method' => $method,
+            'uri' => $uri,
+            'options' => $options,
+        ];
+
+        $method = strtoupper($method);
+
+        // Erst methodengenaue Muster, dann Platzhalter-Methoden — sonst würde
+        // ein '*'-Eintrag eine spezifischere Registrierung verdecken.
+        foreach ([$method, '*'] as $wanted) {
+            foreach ($this->responses as $pattern => $response) {
+                [$patternMethod, $patternUri] = explode(':', $pattern, 2);
+                if ($patternMethod === $wanted && $this->matchUri($uri, $patternUri)) {
+                    return new Response($response['statusCode'], $response['headers'], $response['body']);
+                }
+            }
+        }
+
+        return new Response($this->defaultStatusCode, ['Content-Type' => 'application/json'], $this->defaultBody);
+    }
+
+    private function matchUri(string $uri, string $pattern): bool {
+        if ($uri === $pattern) {
+            return true;
+        }
+
+        $regex = str_replace(['/', '*'], ['\/', '.*'], $pattern);
+
+        return (bool) preg_match('/^' . $regex . '$/', $uri);
+    }
+}

--- a/src/Testing/TestLoggerFactory.php
+++ b/src/Testing/TestLoggerFactory.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : TestLoggerFactory.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace APIToolkit\Testing;
+
+use ERRORToolkit\Enums\LogType;
+use ERRORToolkit\Factories\{ConsoleLoggerFactory, FileLoggerFactory};
+use ERRORToolkit\LoggerRegistry;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logger für Testläufe eines SDK.
+ *
+ * Liefert je nach `<PREFIX>_LOG_TYPE` einen Konsolen- oder Datei-Logger und
+ * trägt ihn in die {@see LoggerRegistry} ein — ohne den Eintrag landen die
+ * Logs des Toolkits im formatarmen syslog-Fallback ohne Aufrufer-Angabe.
+ */
+final class TestLoggerFactory {
+    private static ?LoggerInterface $logger = null;
+
+    /**
+     * @param string $envPrefix Präfix der Umgebungsvariablen, z. B. 'DATEV' für
+     *                          DATEV_LOG_TYPE und DATEV_LOG_FILE
+     */
+    public static function get(string $envPrefix = 'API'): LoggerInterface {
+        if (self::$logger === null) {
+            $logType = self::env($envPrefix . '_LOG_TYPE') ?: LogType::CONSOLE->value;
+
+            self::$logger = match ($logType) {
+                LogType::FILE->value => FileLoggerFactory::getLogger(
+                    self::env($envPrefix . '_LOG_FILE') ?: sys_get_temp_dir() . '/' . strtolower($envPrefix) . '-sdk.log'
+                ),
+                default => ConsoleLoggerFactory::getLogger(),
+            };
+
+            LoggerRegistry::setLogger(self::$logger);
+        }
+
+        return self::$logger;
+    }
+
+    /** Setzt den zwischengespeicherten Logger zurück (für Tests der Factory selbst). */
+    public static function reset(): void {
+        self::$logger = null;
+    }
+
+    private static function env(string $name): ?string {
+        $value = $_ENV[$name] ?? $_SERVER[$name] ?? getenv($name);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/tests/Pagination/LinkHeaderTest.php
+++ b/tests/Pagination/LinkHeaderTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : LinkHeaderTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Pagination;
+
+use APIToolkit\API\Pagination\LinkHeader;
+use GuzzleHttp\Psr7\Response;
+use Tests\Contracts\Test;
+
+class LinkHeaderTest extends Test {
+    public function test_parses_every_relation(): void {
+        $links = LinkHeader::parse('<https://api.example.com/items?page=2>; rel="next", <https://api.example.com/items?page=9>; rel="last"');
+
+        $this->assertSame([
+            'next' => 'https://api.example.com/items?page=2',
+            'last' => 'https://api.example.com/items?page=9',
+        ], $links);
+    }
+
+    public function test_parses_unquoted_and_spaced_relations(): void {
+        $links = LinkHeader::parse('< https://api.example.com/items?page=2 > ; rel = next');
+
+        $this->assertSame('https://api.example.com/items?page=2', $links['next'] ?? null);
+    }
+
+    public function test_relation_names_are_case_insensitive(): void {
+        $this->assertSame(
+            'https://api.example.com/items?page=2',
+            LinkHeader::parse('<https://api.example.com/items?page=2>; rel="NEXT"')['next'] ?? null
+        );
+    }
+
+    public function test_empty_and_malformed_headers_yield_nothing(): void {
+        $this->assertSame([], LinkHeader::parse(''));
+        $this->assertSame([], LinkHeader::parse('   '));
+        $this->assertSame([], LinkHeader::parse('https://api.example.com/items?page=2; rel="next"'));
+        $this->assertNull(LinkHeader::next(''));
+    }
+
+    public function test_parses_relative_targets_without_a_space_before_rel(): void {
+        // Form der DATEV-Online-Dienste (accounting-clients)
+        $links = LinkHeader::parse('<?skip=0&top=100>;rel="prev", <?skip=200&top=100>;rel="next"');
+
+        $this->assertSame('?skip=0&top=100', $links['prev'] ?? null);
+        $this->assertSame('?skip=200&top=100', $links['next'] ?? null);
+    }
+
+    public function test_reads_the_header_from_a_response(): void {
+        $response = new Response(200, ['Link' => '<https://api.example.com/items?page=3>; rel="next"']);
+
+        $this->assertSame('https://api.example.com/items?page=3', LinkHeader::fromResponse($response)['next'] ?? null);
+    }
+}

--- a/tests/Testing/MockApiClientTest.php
+++ b/tests/Testing/MockApiClientTest.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * Created on   : Wed Jul 29 2026
+ * Author       : Daniel Jörg Schuppelius
+ * Author Uri   : https://schuppelius.org
+ * Filename     : MockApiClientTest.php
+ * License      : MIT License
+ * License Uri  : https://opensource.org/license/mit
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Testing;
+
+use APIToolkit\Testing\MockApiClient;
+use Tests\Contracts\Test;
+
+class MockApiClientTest extends Test {
+    public function test_registered_response_is_returned_and_logged(): void {
+        $client = (new MockApiClient)->addResponse('GET', 'article/90', 200, '{"id":90}');
+
+        $response = $client->get('article/90', ['query' => ['x' => 1]]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{"id":90}', (string) $response->getBody());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+
+        $last = $client->getLastRequest();
+        $this->assertNotNull($last);
+        $this->assertSame('GET', $last['method']);
+        $this->assertSame('article/90', $last['uri']);
+        $this->assertSame(['query' => ['x' => 1]], $last['options']);
+        $this->assertCount(1, $client->getRequestLog());
+    }
+
+    public function test_wildcards_match_uris_and_methods(): void {
+        $client = (new MockApiClient)
+            ->addResponse('GET', 'article/*', 200, '{"matched":"uri-wildcard"}')
+            ->addResponse('*', 'invoice/7', 201, '{"matched":"method-wildcard"}');
+
+        $this->assertSame('{"matched":"uri-wildcard"}', (string) $client->get('article/123')->getBody());
+        $this->assertSame('{"matched":"method-wildcard"}', (string) $client->put('invoice/7')->getBody());
+    }
+
+    public function test_specific_method_wins_over_wildcard(): void {
+        $client = (new MockApiClient)
+            ->addResponse('*', 'invoice/7', 200, '{"from":"wildcard"}')
+            ->addResponse('DELETE', 'invoice/7', 204, '');
+
+        $this->assertSame(204, $client->delete('invoice/7')->getStatusCode());
+        $this->assertSame(200, $client->post('invoice/7')->getStatusCode());
+    }
+
+    public function test_unmatched_uri_falls_back_to_the_default_response(): void {
+        $client = (new MockApiClient)->setDefaultResponse(404, '{"message":"not found"}');
+
+        $response = $client->patch('unbekannt');
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('{"message":"not found"}', (string) $response->getBody());
+    }
+
+    public function test_log_and_responses_can_be_cleared(): void {
+        $client = (new MockApiClient)->addResponse('GET', 'ping', 200, '{"pong":true}');
+        $client->get('ping');
+
+        $client->clearRequestLog();
+        $this->assertSame([], $client->getRequestLog());
+        $this->assertNull($client->getLastRequest());
+
+        $client->clearResponses();
+        $this->assertSame('{}', (string) $client->get('ping')->getBody());
+    }
+}


### PR DESCRIPTION
## Warum

Ein Konsolidierungslauf über die drei SDKs hat vier Stellen gefunden, an denen dasselbe mehrfach existiert oder das Fundament fehlt:

| Befund | Beleg |
| --- | --- |
| `MockApiClient` doppelt | orgaMAX und Lexoffice, nach Namespace-Normalisierung **byte-gleich** (159 Zeilen) — der einzige Datei-Zwilling im Bestand |
| Test-Logger-Setup dreifach | 28 / 86 / 165 Zeilen Factory, Lexoffice ohne `LoggerRegistry` → Toolkit-Logs im syslog-Fallback |
| `PagedEndpointAbstract` doppelt | Lexoffice (page/size) und orgaMAX (limit/offset): nach Normalisierung 31 von ~65 Zeilen unterschiedlich, und das nur wegen der Parameternamen |
| Link-Header-Parsing doppelt | `LinkHeaderPaginator::parseNextLink()` und DATEVs `LinkHeaderParser` |

## Was drin ist

- **`Testing\MockApiClient`** — Client-Attrappe für Endpoint-Tests, mit Methoden-/URI-Mustern und Aufruf-Protokoll. Die Reihenfolge-Auflösung ist explizit: methodengenaue Muster schlagen `*`-Einträge.
- **`Testing\TestLoggerFactory`** — Konsolen- oder Datei-Logger je `<PREFIX>_LOG_TYPE`, immer mit Registry-Eintrag.
- **`Contracts\Abstracts\API\PagedEndpointAbstract`** — `searchAll()` über den `OffsetPaginator`; ein SDK gibt nur `pageQueryParams()` und `pageItems()` vor.
- **`API\Pagination\LinkHeader`** — RFC-8288-Parser für alle Relationen; `LinkHeaderPaginator` delegiert dorthin. Die Header-Form der DATEV-Online-Dienste (`<?skip=0&top=100>;rel="prev"`) ist als Regressionsfall abgedeckt.
- **README**: Tabelle aller Bausteine mit Angabe, welche SDKs sie nutzen — und die Einordnung, dass `WebhookVerifier`, `Psr16ResponseCache`, `PendingRequest` und `Psr18Transport` bewusst der einbettenden Anwendung gehören, statt als Lücke gelesen zu werden.

## Prüfung

`composer qa` grün: Pint, PHPStan Level 8 (src + tests), 318 Tests. Die drei SDKs laufen lokal gegen diesen Stand ebenfalls grün; ihre PRs setzen `^2.8` voraus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)